### PR TITLE
Adds a summary argument

### DIFF
--- a/piplicenses.py
+++ b/piplicenses.py
@@ -344,7 +344,7 @@ def create_parser():
     parser.add_argument('--summary',
                         action='store_true',
                         default=False,
-                        help='show license use summary only')
+                        help='dump summary of each license')
 
     return parser
 

--- a/piplicenses.py
+++ b/piplicenses.py
@@ -59,10 +59,22 @@ FIELD_NAMES = (
 )
 
 
+SUMMARY_FIELD_NAMES = (
+    'License',
+    'Count'
+)
+
+
 DEFAULT_OUTPUT_FIELDS = (
     'Name',
     'Version',
     'License',
+)
+
+
+SUMMARY_OUTPUT_FIELDS = (
+    'License',
+    'Count'
 )
 
 
@@ -84,7 +96,8 @@ SYSTEM_PACKAGES = (
 LICENSE_UNKNOWN = 'UNKNOWN'
 
 
-def create_licenses_table(args):
+def get_packages(args):
+
     def get_pkg_info(pkg):
         pkg_info = {
             'name': pkg.project_name,
@@ -117,8 +130,6 @@ def create_licenses_table(args):
 
         return pkg_info
 
-    table = factory_styled_table_with_args(args)
-
     pkgs = get_installed_distributions()
     ignore_pkgs_as_lower = [pkg.lower() for pkg in args.ignore_packages]
     for pkg in pkgs:
@@ -131,12 +142,34 @@ def create_licenses_table(args):
         if not args.with_system and pkg_name in SYSTEM_PACKAGES:
             continue
 
-        table.add_row([pkg_info['name'],
-                       pkg_info['version'],
-                       pkg_info['license'],
-                       pkg_info['author'],
-                       pkg_info['home-page'], ])
+        yield pkg_info
 
+
+def create_licenses_table(args):
+    table = factory_styled_table_with_args(args)
+
+    for pkg in get_packages(args):
+        table.add_row([pkg['name'],
+                       pkg['version'],
+                       pkg['license'],
+                       pkg['author'],
+                       pkg['home-page'], ])
+
+    return table
+
+
+def create_summary_table(args):
+    licenses = {}
+    for pkg in get_packages(args):
+        if pkg['license'] not in licenses:
+            licenses.update({pkg['license']: 1})
+        else:
+            licenses[pkg['license']] += 1
+
+    table = factory_styled_table_with_args(args)
+    for license in licenses.keys():
+        table.add_row([license,
+                       licenses[license], ])
     return table
 
 
@@ -172,7 +205,10 @@ class JsonPrettyTable(PrettyTable):
 
 def factory_styled_table_with_args(args):
     table = PrettyTable()
-    table.field_names = FIELD_NAMES
+    if args.summary:
+        table.field_names = SUMMARY_FIELD_NAMES
+    else:
+        table.field_names = FIELD_NAMES
     table.align = 'l'
     table.border = (args.format_markdown or args.format_rst or
                     args.format_confluence or args.format_json)
@@ -208,6 +244,9 @@ def find_license_from_classifier(message):
 
 
 def get_output_fields(args):
+    if args.summary:
+        return list(SUMMARY_OUTPUT_FIELDS)
+
     output_fields = list(DEFAULT_OUTPUT_FIELDS)
 
     if args.with_authors:
@@ -220,6 +259,9 @@ def get_output_fields(args):
 
 
 def get_sortby(args):
+    if args.summary:
+        return 'License'
+
     if args.order == 'name':
         return 'Name'
     elif args.order == 'license':
@@ -233,7 +275,11 @@ def get_sortby(args):
 
 
 def create_output_string(args):
-    table = create_licenses_table(args)
+    if args.summary:
+        table = create_summary_table(args)
+    else:
+        table = create_licenses_table(args)
+
     output_fields = get_output_fields(args)
     sortby = get_sortby(args)
 
@@ -296,6 +342,10 @@ def create_parser():
                         action='store_true',
                         default=False,
                         help='dump as json')
+    parser.add_argument('--summary',
+                        action='store_true',
+                        default=False,
+                        help='show license use summary only')
 
     return parser
 

--- a/piplicenses.py
+++ b/piplicenses.py
@@ -60,8 +60,8 @@ FIELD_NAMES = (
 
 
 SUMMARY_FIELD_NAMES = (
+    'Count',
     'License',
-    'Count'
 )
 
 
@@ -73,8 +73,8 @@ DEFAULT_OUTPUT_FIELDS = (
 
 
 SUMMARY_OUTPUT_FIELDS = (
+    'Count',
     'License',
-    'Count'
 )
 
 
@@ -168,8 +168,8 @@ def create_summary_table(args):
 
     table = factory_styled_table_with_args(args)
     for license in licenses.keys():
-        table.add_row([license,
-                       licenses[license], ])
+        table.add_row([licenses[license],
+                       license, ])
     return table
 
 
@@ -259,13 +259,12 @@ def get_output_fields(args):
 
 
 def get_sortby(args):
-    if args.summary:
+    if args.summary and args.order == 'count':
+        return 'Count'
+    elif args.summary or args.order == 'license':
         return 'License'
-
-    if args.order == 'name':
+    elif args.order == 'name':
         return 'Name'
-    elif args.order == 'license':
-        return 'License'
     elif args.order == 'author' and args.with_authors:
         return 'Author'
     elif args.order == 'url' and args.with_urls:

--- a/test_piplicenses.py
+++ b/test_piplicenses.py
@@ -232,5 +232,35 @@ class TestGetLicenses(CommandLineTestCase):
         self.assertIn('"Author":', output_string)
         self.assertNotIn('"URL":', output_string)
 
+    def test_summary(self):
+        format_html_args = ['--summary']
+        args = self.parser.parse_args(format_html_args)
+        output_string = create_output_string(args)
+
+        self.assertIn('Count', output_string)
+        self.assertNotIn('Name', output_string)
+
+    def test_summary(self):
+        format_html_args = ['--summary', '-o count']
+        args = self.parser.parse_args(format_html_args)
+        output_string = create_output_string(args)
+
+        self.assertIn('Count', output_string)
+        self.assertNotIn('Name', output_string)
+
+    def test_summary_sort_by_count(self):
+        order_url_args = ['--summary', '--order=count']
+        args = self.parser.parse_args(order_url_args)
+
+        sortby = get_sortby(args)
+        self.assertEquals('Count', sortby)
+
+    def test_summary_sort_by_name(self):
+        order_url_args = ['--summary', '--order=name']
+        args = self.parser.parse_args(order_url_args)
+
+        sortby = get_sortby(args)
+        self.assertEquals('License', sortby)
+
     def tearDown(self):
         pass


### PR DESCRIPTION
This allows the user to pass `pip-licenses --summary` which then provides output like so:

```bash
$ python ./piplicenses.py --summary
 Count  License
 1      ASL
 2      Apache 2.0
 8      BSD
 2      BSD License
 1      BSD or Apache License, Version 2.0
 1      BSD-like
 2      Expat license
 1      GPL
 2      LGPL
 14     MIT
 1      MIT License
 3      MIT license
 1      MPL-2.0
 1      PSF
 2      UNKNOWN
 1      http://opensource.org/licenses/MIT
 1      public domain, Python, 2-Clause BSD, GPL 3 (see COPYING.txt)
```

All output `--format-*` flags work with `--summary`, as do `--from-classifier`, `--with-system`, `--order` and `-i`. However, due to the nature of the summary only, `--with-authors` and `--with-urls` cannot take affect when `--summary` has been activated.