### PR TITLE
Add option to pull license file path and contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Dump the software license list of Python packages installed with pip.
     * [Option: with\-authors](#option-with-authors)
     * [Option: with\-urls](#option-with-urls)
     * [Option: with\-description](#option-with-description)
+    * [Option: with\-license\-file](#option-with-license-file)
     * [Option: ignore\-packages](#option-ignore-packages)
     * [Option: order](#option-order)
     * [Option: format\-markdown](#option-format-markdown)
@@ -143,6 +144,11 @@ When executed with the `--with-description` option, output with short descriptio
  Django  2.0.2    BSD      A high-level Python Web framework that encourages rapid development and clean, pragmatic design.
  pytz    2017.3   MIT      World timezone definitions, modern and historical
 ```
+
+### Option: with-license-file
+
+When executed with the `--with-license-file` option, output the location of the package's license file on disk and the full contents of that file. Due to the length of these fields, this option is best paired with `--format-json`.
+
 
 ### Option: ignore-packages
 

--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -7,6 +7,7 @@ wheel
 pip-tools
 pypandoc
 pytest-cov
+pytest-pep8
 pytest-pycodestyle
 pytest-runner
 twine

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -16,10 +16,9 @@ codecov==2.0.15
 coverage==4.5.2           # via codecov, pytest-cov
 docutils==0.14
 execnet==1.5.0            # via pytest-cache
-funcsigs==1.0.2           # via pytest
 idna==2.8                 # via requests
 more-itertools==4.3.0     # via pytest
-pathlib2==2.3.3           # via pytest
+pep8==1.7.1               # via pytest-pep8
 pip-tools==3.2.0
 pkginfo==1.4.2            # via twine
 pluggy==0.8.0             # via pytest
@@ -28,16 +27,16 @@ py==1.7.0                 # via pytest
 pycodestyle==2.4.0        # via autopep8, pytest-pycodestyle
 pygments==2.3.1           # via readme-renderer
 pypandoc==1.4
-pytest-cache==1.0         # via pytest-pycodestyle
+pytest-cache==1.0         # via pytest-pep8, pytest-pycodestyle
 pytest-cov==2.6.0
+pytest-pep8==1.0.6
 pytest-pycodestyle==1.0.6
 pytest-runner==4.2
-pytest==4.0.2             # via pytest-cache, pytest-cov, pytest-pycodestyle
+pytest==4.0.2             # via pytest-cache, pytest-cov, pytest-pep8, pytest-pycodestyle
 readme-renderer==24.0     # via twine
 requests-toolbelt==0.8.0  # via twine
 requests==2.21.0          # via codecov, requests-toolbelt, twine
-scandir==1.9.0            # via pathlib2
-six==1.12.0               # via bleach, more-itertools, pathlib2, pip-tools, pytest, readme-renderer
+six==1.12.0               # via bleach, more-itertools, pip-tools, pytest, readme-renderer
 tqdm==4.28.1              # via twine
 twine==1.12.1
 urllib3==1.24.1           # via requests

--- a/test_piplicenses.py
+++ b/test_piplicenses.py
@@ -148,6 +148,15 @@ class TestGetLicenses(CommandLineTestCase):
         self.assertNotEquals(output_fields, list(DEFAULT_OUTPUT_FIELDS))
         self.assertIn('Description', output_fields)
 
+    def test_with_license_file(self):
+        with_license_file_args = ['--with-license-file']
+        args = self.parser.parse_args(with_license_file_args)
+
+        output_fields = get_output_fields(args)
+        self.assertNotEqual(output_fields, list(DEFAULT_OUTPUT_FIELDS))
+        self.assertIn('LicenseFile', output_fields)
+        self.assertIn('LicenseText', output_fields)
+
     def test_ignore_packages(self):
         ignore_pkg_name = 'PTable'
         ignore_packages_args = ['--ignore-package=' + ignore_pkg_name]


### PR DESCRIPTION
My organization needs the ability to pull the license file path and contents, similar to how npm [license-checker](https://www.npmjs.com/package/license-checker) does when using `--customPath licenseText`. This adds that functionality with the `--with-license-file` argument.

During testing I also found a missing development dependency, hence the updates to `dev-requirements.in` (and the re-computed `dev-requirements.txt`) in a separate commit.