### PR TITLE
Add option to pull license file path and contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Dump the software license list of Python packages installed with pip.
     * [Option: with\-authors](#option-with-authors)
     * [Option: with\-urls](#option-with-urls)
     * [Option: with\-description](#option-with-description)
+    * [Option: with\-license\-file](#option-with-license-file)
     * [Option: ignore\-packages](#option-ignore-packages)
     * [Option: order](#option-order)
     * [Option: format\-markdown](#option-format-markdown)
@@ -143,6 +144,11 @@ When executed with the `--with-description` option, output with short descriptio
  Django  2.0.2    BSD      A high-level Python Web framework that encourages rapid development and clean, pragmatic design.
  pytz    2017.3   MIT      World timezone definitions, modern and historical
 ```
+
+### Option: with-license-file
+
+When executed with the `--with-license-file` option, output the location of the package's license file on disk and the full contents of that file. Due to the length of these fields, this option is best paired with `--format-json`.
+
 
 ### Option: ignore-packages
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,4 +3,4 @@ universal=1
 [aliases]
 test=pytest
 [tool:pytest]
-addopts=--pep8 -v --cov
+addopts=--pep8 -v --cov --cov-report term-missing

--- a/test_piplicenses.py
+++ b/test_piplicenses.py
@@ -132,6 +132,9 @@ class TestGetLicenses(CommandLineTestCase):
         self.assertNotEquals(output_fields, list(DEFAULT_OUTPUT_FIELDS))
         self.assertIn('Author', output_fields)
 
+        output_string = create_output_string(args)
+        self.assertIn('Author', output_string)
+
     def test_with_urls(self):
         with_urls_args = ['--with-urls']
         args = self.parser.parse_args(with_urls_args)
@@ -140,6 +143,9 @@ class TestGetLicenses(CommandLineTestCase):
         self.assertNotEquals(output_fields, list(DEFAULT_OUTPUT_FIELDS))
         self.assertIn('URL', output_fields)
 
+        output_string = create_output_string(args)
+        self.assertIn('URL', output_string)
+
     def test_with_description(self):
         with_description_args = ['--with-description']
         args = self.parser.parse_args(with_description_args)
@@ -147,6 +153,9 @@ class TestGetLicenses(CommandLineTestCase):
         output_fields = get_output_fields(args)
         self.assertNotEquals(output_fields, list(DEFAULT_OUTPUT_FIELDS))
         self.assertIn('Description', output_fields)
+
+        output_string = create_output_string(args)
+        self.assertIn('Description', output_string)
 
     def test_ignore_packages(self):
         ignore_pkg_name = 'PTable'

--- a/test_piplicenses.py
+++ b/test_piplicenses.py
@@ -157,6 +157,19 @@ class TestGetLicenses(CommandLineTestCase):
         output_string = create_output_string(args)
         self.assertIn('Description', output_string)
 
+    def test_with_license_file(self):
+        with_license_file_args = ['--with-license-file']
+        args = self.parser.parse_args(with_license_file_args)
+
+        output_fields = get_output_fields(args)
+        self.assertNotEqual(output_fields, list(DEFAULT_OUTPUT_FIELDS))
+        self.assertIn('LicenseFile', output_fields)
+        self.assertIn('LicenseText', output_fields)
+
+        output_string = create_output_string(args)
+        self.assertIn('LicenseFile', output_string)
+        self.assertIn('LicenseText', output_string)
+
     def test_ignore_packages(self):
         ignore_pkg_name = 'PTable'
         ignore_packages_args = ['--ignore-package=' + ignore_pkg_name]


### PR DESCRIPTION
My organization needs the ability to pull the license file path and contents, similar to how npm [license-checker](https://www.npmjs.com/package/license-checker) does when using `--customPath licenseText`. This adds that functionality with the `--with-license-file` argument.

While validating this, I discovered that PTable determines vertical table layout based on the data in the row even if those fields won't be output. Hence commit 90470ab to only add fields to the row if we want to output them. I've broken that into a separate logical commit but can break it out into another PR if that would be preferred.

During testing I also found a missing development dependency, hence the updates to `dev-requirements.in` (and the re-computed `dev-requirements.txt`) in a separate commit.
