### PR TITLE
Minor fixes to Docker stuff

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,17 @@
 FROM python:3.7.2-alpine
 LABEL maintainer="raimon <raimon49@hotmail.com>"
 
-WORKDIR /opt/piplicenses
+ARG APPDIR=/opt/piplicenses
 
-COPY ./docker/requirements.txt /opt/piplicenses
+WORKDIR ${APPDIR}
 
-RUN python3 -m venv /opt/piplicenses/myapp \
-        && source /opt/piplicenses/myapp/bin/activate
+COPY ./docker/requirements.txt ${APPDIR}
+
+RUN python3 -m venv ${APPDIR}/myapp \
+        && source ${APPDIR}/myapp/bin/activate
+
 RUN pip3 install -U pip \
-        && pip3 install -r /opt/piplicenses/requirements.txt \
+        && pip3 install -r ${APPDIR}/requirements.txt \
         && pip3 install -U pip-licenses
 
 ENTRYPOINT ["pip-licenses"]

--- a/README.md
+++ b/README.md
@@ -326,14 +326,14 @@ $ docker run --rm myapp-licenses
  Flask         1.0.2    BSD License
  Jinja2        2.10     BSD License
  MarkupSafe    1.1.1    BSD License
- Werkzeug      0.14.1   BSD License
+ Werkzeug      0.15.2   BSD License
  itsdangerous  1.1.0    BSD License
 
 # Check with options
 $ docker run --rm myapp-licenses --summary
  Count  License
- 5      BSD
- 1      BSD-3-Clause
+ 4      BSD
+ 2      BSD-3-Clause
 
 # When you need help
 $ docker run --rm myapp-licenses --help


### PR DESCRIPTION
@raimon49 thanks for this AWESOME project!

 I use it in CI for a few projects where I want to be really careful about unwanted licenses like GPL sneaking into my dependency tree.

Because I use `pip-licenses` so much, I wanted to come into the project today and spend some time learning how the internals work.

I really like the Docker setup you have, and hope you'll consider this PR that makes two small changes to it.

* Docker supports the use of `ARG` for storing (basically) environment variables that are only used at build time. I recommend centralizing the path `/opt/piplicenses` (which is manually copied in multiple places) in an `ARG` to improve the readability of your `Dockerfile` and reduce the risk of copy-paste errors if contributors add to it in the future
* While running through the Docker example in the README, I found that the outputs have changed slightly thanks to newer versions of `Werkzeug` being published
