### PR TITLE
feat: Add JSONLicenseFinder

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Dump the software license list of Python packages installed with pip.
         * [Confluence](#confluence)
         * [HTML](#html)
         * [JSON](#json)
+        * [JSON LicenseFinder](#json-licensefinder)
         * [CSV](#csv)
         * [Deprecated options](#deprecated-options)
     * [Option: summary](#option-summary)
@@ -287,6 +288,27 @@ When executed with the `--format=json` option, you can output list in JSON forma
     "Name": "pytz",
     "URL": "http://pythonhosted.org/pytz",
     "Version": "2017.3"
+  }
+]
+
+```
+
+#### JSON LicenseFinder
+
+When executed with the `--format=json-license-finder` option, you can output list in JSON format that is identical to [LicenseFinder](https://github.com/pivotal/LicenseFinder). The `jlf` keyword is prepared as alias of `jlf`.
+This makes pip-licenses a drop-in replacement for LicenseFinder.
+
+```json
+[
+  {
+    "licenses": ["BSD"],
+    "name": "Django",
+    "version": "2.0.2"
+  },
+  {
+    "licenses": ["MIT"],
+    "name": "pytz",
+    "version": "2017.3"
   }
 ]
 

--- a/piplicenses.py
+++ b/piplicenses.py
@@ -256,6 +256,38 @@ class JsonPrettyTable(PrettyTable):
         return json.dumps(lines, indent=2, sort_keys=True)
 
 
+class JsonLicenseFinderTable(JsonPrettyTable):
+    def _format_row(self, row, options):
+        resrow = {}
+        for (field, value) in zip(self._field_names, row):
+            if field == 'Name':
+                resrow['name'] = value
+
+            if field == 'Version':
+                resrow['version'] = value
+
+            if field == 'License':
+                resrow['licenses'] = [value]
+
+        return resrow
+
+    def get_string(self, **kwargs):
+        # import included here in order to limit dependencies
+        # if not interested in JSON output,
+        # then the dependency is not required
+        import json
+
+        options = self._get_options(kwargs)
+        rows = self._get_rows(options)
+        formatted_rows = self._format_rows(rows, options)
+
+        lines = []
+        for row in formatted_rows:
+            lines.append(row)
+
+        return json.dumps(lines, sort_keys=True)
+
+
 class CSVPrettyTable(PrettyTable):
     """PrettyTable-like class exporting to CSV"""
 
@@ -308,6 +340,8 @@ def factory_styled_table_with_args(args, output_fields=DEFAULT_OUTPUT_FIELDS):
         table.hrules = RULE_NONE
     elif args.format == 'json':
         table = JsonPrettyTable(table.field_names)
+    elif args.format == 'json-license-finder':
+        table = JsonLicenseFinderTable(table.field_names)
     elif args.format == 'csv':
         table = CSVPrettyTable(table.field_names)
 
@@ -481,6 +515,9 @@ class CompatibleArgumentParser(argparse.ArgumentParser):
 
         if format_input in ('json', 'j'):
             args.format = 'json'
+
+        if format_input in ('json-license-finder', 'jlf'):
+            args.format = 'json-license-finder'
 
         if format_input in ('csv', ):
             args.format = 'csv'

--- a/test_piplicenses.py
+++ b/test_piplicenses.py
@@ -321,6 +321,16 @@ class TestGetLicenses(CommandLineTestCase):
         self.assertIn('"Author":', output_string)
         self.assertNotIn('"URL":', output_string)
 
+    def test_format_json_license_manager(self):
+        format_json_args = ['--format=json-license-finder']
+        args = self.parser.parse_args(format_json_args)
+        output_string = create_output_string(args)
+
+        self.assertNotIn('"URL":', output_string)
+        self.assertIn('"name":', output_string)
+        self.assertIn('"version":', output_string)
+        self.assertIn('"licenses":', output_string)
+
     def test_format_csv(self):
         format_csv_args = ['--format=csv', '--with-authors']
         args = self.parser.parse_args(format_csv_args)


### PR DESCRIPTION
Hi 👋 

I took the liberty of adding a --json-license-finder option to pip-licenses. This makes pip-licenses a drop-in replacement for LicenseFinder (https://github.com/pivotal/LicenseFinder) which is used by LicenseManagement in Gitlab's AutoDevops.

The issue with LicenseFinder is that it can only scan dependencies up until python 3.5 and not 3.6. pip-licenses is way better in that regard! However if we want to use the bindings inside Gitlab CI we need the output of pip-licenses to be the same as LicenseFinder.

From reading the source it wasn't immediately clear if pip-licenses supports overriding the json format that is outputted, if it does please point me in the right direction!

To me this seems like a clean solution. Suggestions on how to improve this PR are very welcome, this is my first PR into this project!

Alexander