### PR TITLE
Allow using prettytable

### DIFF
--- a/piplicenses.py
+++ b/piplicenses.py
@@ -42,8 +42,22 @@ try:
 except ImportError:
     from pip import get_installed_distributions
 from prettytable import PrettyTable
-from prettytable.prettytable import (FRAME as RULE_FRAME, ALL as RULE_ALL,
-                                     HEADER as RULE_HEADER, NONE as RULE_NONE)
+try:
+    from prettytable.prettytable import (
+        ALL as RULE_ALL,
+        FRAME as RULE_FRAME,
+        HEADER as RULE_HEADER,
+        NONE as RULE_NONE,
+    )
+    PTABLE = True
+except ImportError:  # pragma: no cover
+    from prettytable import (
+        ALL as RULE_ALL,
+        FRAME as RULE_FRAME,
+        HEADER as RULE_HEADER,
+        NONE as RULE_NONE,
+    )
+    PTABLE = False
 
 __pkgname__ = 'pip-licenses'
 __version__ = '1.17.0'
@@ -102,7 +116,7 @@ FIELDS_TO_METADATA_KEYS = {
 SYSTEM_PACKAGES = (
     __pkgname__,
     'pip',
-    'PTable',
+    'PTable' if PTABLE else 'prettytable',
     'setuptools',
     'wheel',
 )

--- a/test_piplicenses.py
+++ b/test_piplicenses.py
@@ -5,13 +5,12 @@ from __future__ import (division, print_function,
 import unittest
 from email import message_from_string
 
-from prettytable.prettytable import (FRAME as RULE_FRAME, ALL as RULE_ALL,
-                                     HEADER as RULE_HEADER, NONE as RULE_NONE)
 from piplicenses import (__pkgname__, create_parser, output_colored,
                          create_licenses_table, get_output_fields, get_sortby,
                          factory_styled_table_with_args, create_warn_string,
                          find_license_from_classifier, create_output_string,
                          select_license_by_source, save_if_needs,
+                         RULE_ALL, RULE_FRAME, RULE_HEADER, RULE_NONE,
                          DEFAULT_OUTPUT_FIELDS, SYSTEM_PACKAGES,
                          LICENSE_UNKNOWN)
 
@@ -219,7 +218,10 @@ class TestGetLicenses(CommandLineTestCase):
         self.assertIn('best paired with --format=json', warn_string)
 
     def test_ignore_packages(self):
-        ignore_pkg_name = 'PTable'
+        if 'PTable' in SYSTEM_PACKAGES:
+            ignore_pkg_name = 'PTable'
+        else:
+            ignore_pkg_name = 'prettytable'
         ignore_packages_args = ['--ignore-package=' + ignore_pkg_name]
         args = self.parser.parse_args(ignore_packages_args)
         table = create_licenses_table(args)


### PR DESCRIPTION
PTable and prettytable conflict, both using package name 'prettytable'
with one as prettytable.py and the other as prettytable/.
pip provides no protection against two packages conflicting like
these.

PTable hasnt maintained backwards compatability, and hasnt been
doing releases for a while.

This patch allows either to be present.