### PR TITLE
Fix reading license files with windows newlines

### DIFF
--- a/piplicenses.py
+++ b/piplicenses.py
@@ -29,7 +29,6 @@ SOFTWARE.
 import sys
 import glob
 import os
-import codecs
 import argparse
 from functools import partial
 from email.parser import FeedParser
@@ -56,6 +55,8 @@ except ImportError:  # pragma: no cover
         NONE as RULE_NONE,
     )
     PTABLE = False
+
+open = open  # allow monkey patching
 
 __pkgname__ = 'pip-licenses'
 __version__ = '2.0.0'
@@ -137,17 +138,8 @@ def get_packages(args):
         for test_file in glob.glob(license_file_base):
             if os.path.exists(test_file):
                 license_file = test_file
-                with codecs.open(test_file,
-                                 encoding='utf-8',
-                                 errors='replace') as license_file_handle:
-                    file_lines = license_file_handle.readlines()
-                try:
-                    # python 3 is happy with maybe-Unicode files
-                    license_text = "".join(file_lines)
-                except UnicodeDecodeError:  # pragma: no cover
-                    # python 2 not so much
-                    license_text = "".join([line.decode('utf-8', 'replace')
-                                            for line in file_lines])
+                with open(test_file) as license_file_handle:
+                    license_text = license_file_handle.read()
                 break
         return (license_file, license_text)
 
@@ -611,7 +603,7 @@ def save_if_needs(output_file, output_string):
         return
 
     try:
-        with codecs.open(output_file, 'w', 'utf-8',) as f:
+        with open(output_file, 'w') as f:
             f.write(output_string)
         sys.stdout.write('created path: ' + output_file + '\n')
         sys.exit(0)

--- a/test_piplicenses.py
+++ b/test_piplicenses.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 # vim:fenc=utf-8 ff=unix ft=python ts=4 sw=4 sts=4 si et
+import copy
+import sys
 import unittest
 from email import message_from_string
 
+import piplicenses
 from piplicenses import (__pkgname__, create_parser, output_colored,
                          create_licenses_table, get_output_fields, get_sortby,
                          factory_styled_table_with_args, create_warn_string,
@@ -20,11 +23,8 @@ class CommandLineTestCase(unittest.TestCase):
 
 
 class TestGetLicenses(CommandLineTestCase):
-    def setUp(self):
-        pass
 
     def _create_pkg_name_columns(self, table):
-        import copy
         index = DEFAULT_OUTPUT_FIELDS.index('Name')
 
         # XXX: access to private API
@@ -36,7 +36,6 @@ class TestGetLicenses(CommandLineTestCase):
         return pkg_name_columns
 
     def _create_license_columns(self, table):
-        import copy
         index = DEFAULT_OUTPUT_FIELDS.index('License')
 
         # XXX: access to private API
@@ -411,9 +410,6 @@ class TestGetLicenses(CommandLineTestCase):
         self.assertIn(text, actual)
         self.assertTrue(actual.endswith('\033[0m'))
 
-    def tearDown(self):
-        pass
-
 
 class MockStdStream(object):
 
@@ -431,9 +427,7 @@ def test_output_file_sccess(monkeypatch):
 
     mocked_stdout = MockStdStream()
     mocked_stderr = MockStdStream()
-    import codecs
-    import sys
-    monkeypatch.setattr(codecs, 'open', mocked_open)
+    monkeypatch.setattr(piplicenses, 'open', mocked_open)
     monkeypatch.setattr(sys.stdout, 'write', mocked_stdout.write)
     monkeypatch.setattr(sys.stderr, 'write', mocked_stderr.write)
     monkeypatch.setattr(sys, 'exit', lambda n: None)
@@ -449,9 +443,7 @@ def test_output_file_error(monkeypatch):
 
     mocked_stdout = MockStdStream()
     mocked_stderr = MockStdStream()
-    import codecs
-    import sys
-    monkeypatch.setattr(codecs, 'open', mocked_open)
+    monkeypatch.setattr(piplicenses, 'open', mocked_open)
     monkeypatch.setattr(sys.stdout, 'write', mocked_stdout.write)
     monkeypatch.setattr(sys.stderr, 'write', mocked_stderr.write)
     monkeypatch.setattr(sys, 'exit', lambda n: None)
@@ -464,8 +456,6 @@ def test_output_file_error(monkeypatch):
 def test_output_file_none(monkeypatch):
     mocked_stdout = MockStdStream()
     mocked_stderr = MockStdStream()
-    import codecs
-    import sys
     monkeypatch.setattr(sys.stdout, 'write', mocked_stdout.write)
     monkeypatch.setattr(sys.stderr, 'write', mocked_stderr.write)
 


### PR DESCRIPTION
Fixes #55.

By using `open()` rather than `codecs.open()` the newline-fixing behaviour from Python 3 can be used.

Presumably `codecs.open()` was used previously to allow proper UTF-8 handling in Python 2, but since that has been dropped the normal `open()` can be used.

Also drop some inner imports in tests and empty `setUp()` and `tearDown()` methods.

Tested with:

```
$ pip install django-cors-headers==3.2.0
$ python piplicenses.py --with-license-file --no-license-path | grep -C 2 django-cors-headers
                                                                                                   END OF TERMS AND CONDITIONS

 django-cors-headers  3.2.0       MIT License                                                   Copyright 2017 Otto Yiu and other contributors
                                                                                                http://ottoyiu.com
```

This showed the same breakage as in the issue before the fix.