### PR TITLE
Add --format=plain-vertical

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ When executed with the `--format=csv` option, you can output list in quoted CSV 
 #### Plain Vertical
 
 When executed with the `--format=plain-vertical` option, you can output a simple plain vertical output that is similar to Angular CLI's
-`--extractLicenses` flag. This format minimizes rightward drift.
+[`--extractLicenses` flag](https://angular.io/cli/build#options). This format minimizes rightward drift.
 
 ```bash
 (venv) $ pip-licenses --format=plain-vertical --with-license-file --no-license-path

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Dump the software license list of Python packages installed with pip.
         * [JSON](#json)
         * [JSON LicenseFinder](#json-licensefinder)
         * [CSV](#csv)
+        * [Plain Vertical](#plain-vertical)
     * [Option: summary](#option-summary)
     * [Option: output\-file](#option-output-file)
     * [More Information](#more-information)

--- a/README.md
+++ b/README.md
@@ -328,6 +328,39 @@ When executed with the `--format=csv` option, you can output list in quoted CSV 
 "pytz","2017.3","MIT"
 ```
 
+#### Plain Vertical
+
+When executed with the `--format=plain-vertical` option, you can output a simple plain vertical output that is similar to Angular CLI's
+`--extractLicenses` flag. This format minimizes rightward drift.
+
+```bash
+(venv) $ pip-licenses --format=plain-vertical --with-license-file --no-license-path
+pytest
+5.3.4
+MIT license
+The MIT License (MIT)
+
+Copyright (c) 2004-2020 Holger Krekel and others
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
 ### Option: summary
 
 When executed with the `--summary` option, you can output a summary of each license.

--- a/piplicenses.py
+++ b/piplicenses.py
@@ -414,8 +414,21 @@ def get_sortby(args):
     return 'Name'
 
 
+def create_plain_vertical_output(args, output_fields):
+    output = ''
+    for pkg in get_packages(args):
+        for field in output_fields:
+            if field.lower() in pkg:
+                output += '{}\n'.format(pkg[field.lower()])
+        output += '\n'
+    return output
+
+
 def create_output_string(args):
     output_fields = get_output_fields(args)
+
+    if args.format == 'plain-vertical':
+        return create_plain_vertical_output(args, output_fields)
 
     if args.summary:
         table = create_summary_table(args)
@@ -566,8 +579,9 @@ def create_parser():
                         action='store', type=str,
                         default='plain', metavar='STYLE',
                         help=('dump as set format style\n'
-                              '"plain", "markdown", "rst", "confluence",\n'
-                              '"html", "json", "json-license-finder",  "csv"\n'
+                              '"plain", "plain-vertical" "markdown", "rst", \n'
+                              '"confluence", "html", "json", \n'
+                              '"json-license-finder",  "csv"\n'
                               'default: --format=plain'))
     parser.add_argument('--summary',
                         action='store_true',

--- a/piplicenses.py
+++ b/piplicenses.py
@@ -320,6 +320,26 @@ class CSVPrettyTable(PrettyTable):
         return '\n'.join(lines)
 
 
+class PlainVerticalTable(PrettyTable):
+    """PrettyTable for outputting to a simple non-column based style.
+
+    When used with --with-license-file, this style is similar to the default
+    style generated from Angular CLI's --extractLicenses flag.
+    """
+
+    def get_string(self, **kwargs):
+        options = self._get_options(kwargs)
+        rows = self._get_rows(options)
+
+        output = ''
+        for row in rows:
+            for v in row:
+                output += '{}\n'.format(v)
+            output += '\n'
+
+        return output
+
+
 def factory_styled_table_with_args(args, output_fields=DEFAULT_OUTPUT_FIELDS):
     table = PrettyTable()
     table.field_names = output_fields
@@ -343,6 +363,8 @@ def factory_styled_table_with_args(args, output_fields=DEFAULT_OUTPUT_FIELDS):
         table = JsonLicenseFinderTable(table.field_names)
     elif args.format == 'csv':
         table = CSVPrettyTable(table.field_names)
+    elif args.format == 'plain-vertical':
+        table = PlainVerticalTable(table.field_names)
 
     return table
 
@@ -414,21 +436,8 @@ def get_sortby(args):
     return 'Name'
 
 
-def create_plain_vertical_output(args, output_fields):
-    output = ''
-    for pkg in get_packages(args):
-        for field in output_fields:
-            if field.lower() in pkg:
-                output += '{}\n'.format(pkg[field.lower()])
-        output += '\n'
-    return output
-
-
 def create_output_string(args):
     output_fields = get_output_fields(args)
-
-    if args.format == 'plain-vertical':
-        return create_plain_vertical_output(args, output_fields)
 
     if args.summary:
         table = create_summary_table(args)

--- a/test_piplicenses.py
+++ b/test_piplicenses.py
@@ -288,8 +288,7 @@ class TestGetLicenses(CommandLineTestCase):
     def test_format_plain_vertical(self):
         format_plain_args = ['--format=plain-vertical']
         args = self.parser.parse_args(format_plain_args)
-        output_string = create_output_string(args)
-        assert output_string == ''
+        create_output_string(args)
 
     def test_format_markdown(self):
         format_markdown_args = ['--format=markdown']

--- a/test_piplicenses.py
+++ b/test_piplicenses.py
@@ -285,6 +285,12 @@ class TestGetLicenses(CommandLineTestCase):
         self.assertEqual('+', table.junction_char)
         self.assertEqual(RULE_FRAME, table.hrules)
 
+    def test_format_plain_vertical(self):
+        format_plain_args = ['--format=plain-vertical']
+        args = self.parser.parse_args(format_plain_args)
+        output_string = create_output_string(args)
+        assert output_string == ''
+
     def test_format_markdown(self):
         format_markdown_args = ['--format=markdown']
         args = self.parser.parse_args(format_markdown_args)

--- a/test_piplicenses.py
+++ b/test_piplicenses.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim:fenc=utf-8 ff=unix ft=python ts=4 sw=4 sts=4 si et
 import copy
+import re
 import sys
 import unittest
 from email import message_from_string
@@ -288,7 +289,9 @@ class TestGetLicenses(CommandLineTestCase):
     def test_format_plain_vertical(self):
         format_plain_args = ['--format=plain-vertical']
         args = self.parser.parse_args(format_plain_args)
-        create_output_string(args)
+        output_string = create_output_string(args)
+        self.assertIsNotNone(
+            re.search(r'pytest\n\d\.\d\.\d\nMIT license\n', output_string))
 
     def test_format_markdown(self):
         format_markdown_args = ['--format=markdown']


### PR DESCRIPTION
Closes #49 

This matches the license style of Angular CLI (which calls [`license-webpack-plugin`](https://github.com/xz64/license-webpack-plugin) internally) and is more pleasing to view on horizontally-constrained environments (like some web pages) when license files are included.