### PR TITLE
WIP: Support pip --path option of pip

### DIFF
--- a/piplicenses.py
+++ b/piplicenses.py
@@ -208,7 +208,7 @@ def get_packages(args):
 
         return pkg_info
 
-    pkgs = get_installed_distributions()
+    pkgs = get_installed_distributions(paths=args.path)
     ignore_pkgs_as_lower = [pkg.lower() for pkg in args.ignore_packages]
     for pkg in pkgs:
         pkg_name = pkg.project_name
@@ -652,6 +652,12 @@ def create_parser():
     parser.add_argument('--output-file',
                         action='store', type=str,
                         help='save license list to file')
+    parser.add_argument('--path',
+                        action='store', type=str,
+                        nargs='+', metavar='PATH',
+                        default=[],
+                        help='restrict to the specified installation path '
+                             'for listing packages')
 
     return parser
 

--- a/test_piplicenses.py
+++ b/test_piplicenses.py
@@ -514,6 +514,16 @@ class TestGetLicenses(CommandLineTestCase):
             self.parser.parse_args(["--filter-strings",
                                     "--filter-code-page=XXX"])
 
+    def test_path(self):
+        args = self.parser.parse_args([])
+        packages = list(piplicenses.get_packages(args))
+        self.assertNotEqual([], packages)
+
+        args = self.parser.parse_args(["--path=."])
+        packages = list(piplicenses.get_packages(args))
+        self.assertEqual(1, len(packages))
+        self.assertIn('pip-license', packages[0]["name"])
+
 
 class MockStdStream(object):
 


### PR DESCRIPTION
Motivation

pip-licenses collects distributions including site.USER_SITE in python 3.6. I would like to exculde the packages in USER_SITE.

Hmm, I can use PYTHONNOUSERSITE as workaround... :thinking: 

### python 3.7


```
% pyenv shell 3.7.5 && python --version && python -m site
Python 3.7.5
sys.path = [
    '/home/kazuhiro',
    '/home/kazuhiro/.pyenv/versions/3.7.5/lib/python37.zip',
    '/home/kazuhiro/.pyenv/versions/3.7.5/lib/python3.7',
    '/home/kazuhiro/.pyenv/versions/3.7.5/lib/python3.7/lib-dynload',
    '/home/kazuhiro/.pyenv/versions/3.7.5/lib/python3.7/site-packages',
]
USER_BASE: '/home/kazuhiro/.local' (exists)
USER_SITE: '/home/kazuhiro/.local/lib/python3.7/site-packages' (doesn't exist)
ENABLE_USER_SITE: True
```

### python 3.6

```
% pyenv shell 3.6.10 && python --version && python -m site
Python 3.6.10
sys.path = [
    '/home/kazuhiro',
    '/home/kazuhiro/.pyenv/versions/3.6.10/lib/python36.zip',
    '/home/kazuhiro/.pyenv/versions/3.6.10/lib/python3.6',
    '/home/kazuhiro/.pyenv/versions/3.6.10/lib/python3.6/lib-dynload',
    '/home/kazuhiro/.local/lib/python3.6/site-packages',             <------- USER_SITE
    '/home/kazuhiro/.pyenv/versions/3.6.10/lib/python3.6/site-packages',
]
USER_BASE: '/home/kazuhiro/.local' (exists)
USER_SITE: '/home/kazuhiro/.local/lib/python3.6/site-packages' (exists)
ENABLE_USER_SITE: True
```


[PR]: https://github.com/pypa/pip/commit/929fefdbae2ddddfd325204b43434310a8600115