### PR TITLE
Added '--from=all' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ In mixed mode, it first tries to look for licenses in the Trove Classifiers. Whe
 
 If you want to looks only in metadata, use `--from=meta`. If you want to looks only in Trove Classifiers, use `--from=classifier`.
 
+To list license information from both metadata and classifier, use `--from=all`.
+
 **Note:** If neither can find license information, please check with the `with-authors` and `with-urls` options and contact the software author.
 
 * The `m` keyword is prepared as alias of `meta`.
@@ -403,13 +405,15 @@ If the input strings are filtered (see `--filter-strings`), you can specify the 
 
 Fail (exit with code 1) on the first occurrence of the licenses of the semicolon-separated list
 
+If `--from=all`, the option will apply to the metadata license field.
+
 ```
 (venv) $ pip-licenses --fail-on="MIT License;BSD License"
 ```
 **Note:** When using this option, pip-licenses looks for an exact match. Packages with multiple licenses will only fail if that license combination is included in the list. For example:
 ```
 # keyring library has 2 licenses, separated by a comma
-$ pip-licenses | grep keyring 
+$ pip-licenses | grep keyring
  keyring             21.4.0     Python Software Foundation License, MIT License
 
 # If just "Python Software Foundation License" is specified, it will succeed.
@@ -425,13 +429,15 @@ $ pip-licenses --fail-on="Python Software Foundation License, MIT License;"
 
 Fail (exit with code 1) on the first occurrence of the licenses not in the semicolon-separated list
 
+If `--from=all`, the option will apply to the metadata license field.
+
 ```
 (venv) $ pip-licenses --allow-only="MIT License;BSD License"
 ```
 **Note:** When using this option, pip-licenses looks for an exact match. Packages with multiple licenses will only be allowed if that license combination is included in the list. For example:
 ```
 # keyring library has 2 licenses, separated by a comma
-$ pip-licenses | grep keyring 
+$ pip-licenses | grep keyring
  keyring             21.4.0     Python Software Foundation License, MIT License
 
 # Both licenses must be specified together.

--- a/test_piplicenses.py
+++ b/test_piplicenses.py
@@ -144,6 +144,31 @@ class TestGetLicenses(CommandLineTestCase):
         license_notation_as_classifier = 'MIT License'
         self.assertIn(license_notation_as_classifier, license_columns)
 
+    def test_from_all(self):
+        from_args = ['--from=all']
+        args = self.parser.parse_args(from_args)
+        output_fields = get_output_fields(args)
+        table = create_licenses_table(args, output_fields)
+
+        self.assertIn('License-Metadata', output_fields)
+        self.assertIn('License-Classifier', output_fields)
+
+        index_license_meta = output_fields.index('License-Metadata')
+        license_meta = []
+        for row in table._rows:
+            license_meta.append(row[index_license_meta])
+
+        index_license_classifier = output_fields.index('License-Classifier')
+        license_classifier = []
+        for row in table._rows:
+            license_classifier.append(row[index_license_classifier])
+
+        for license in ('BSD', 'MIT', 'Apache 2.0'):
+            self.assertIn(license, license_meta)
+        for license in ('BSD License', 'MIT License',
+                        'Apache Software License'):
+            self.assertIn(license, license_classifier)
+
     def test_find_license_from_classifier(self):
         metadata = ('Metadata-Version: 2.0\r\n'
                     'Name: pip-licenses\r\n'


### PR DESCRIPTION
At the moment `pip-licenses` can only output **either** the metadata **or** the classifier license information.
This PR adds the `--from=all` option that displays both license information at the same time .

**Background**
[PEP 639](https://www.python.org/dev/peps/pep-0639/) specified how Python packages are supposed to define license information going forward. The preferred way is to use the `license` metadata field with SPDX license expression [syntax](https://www.python.org/dev/peps/pep-0639/#license-expression-syntax). Although not officially deprecated, the trove classifiers will slowly be phased out and won't receive any more updates.
Since the PEP is only from Aug-2019, most packages still use the trove class and/or have outdated/invalid metadata license information. With the proposed option, it will be easier to compare the used licenses.

**Going forward**
- `--from=mixed` still prefers the classifier over metadata information. Changing this would be a big breaking change and probably confuse many users. Therefore I'm not sure if it will be worth it. At least not for now.
- Update the metadata `license` information for `pip-licenses` to just `MIT` to conform with the SPDX identifier.
- Try parsing the metadata license field and extracting SPDX identifiers.

**Ideas**
- Add option to auto-convert classifier to SPDX identifier (when possible, eg. only in simple cases)
- Parse SPDX license expression to better evaluate `fail` / `allow`
- Add license pinning, would be useful for CI integrations to require manual approval if license for specific package changes. This would probably work best with a config file.

--

## Next steps for this PR
- [x] Finalize implementation details
- [x] Add test case(s)