### PR TITLE
Improve argparser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,9 @@ ENV/
 # ignore files to run in docker
 docker/*
 !docker/.gitkeep
+
+# Windows
+[Dd]esktop.ini
+
+# macOS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -10,29 +10,32 @@ Dump the software license list of Python packages installed with pip.
 * [Installation](#installation)
 * [Usage](#usage)
 * [Command\-Line Options](#command-line-options)
-    * [Option: from](#option-from)
-    * [Option: with\-system](#option-with-system)
-    * [Option: with\-authors](#option-with-authors)
-    * [Option: with\-urls](#option-with-urls)
-    * [Option: with\-description](#option-with-description)
-    * [Option: with\-license\-file](#option-with-license-file)
-    * [Option: ignore\-packages](#option-ignore-packages)
-    * [Option: order](#option-order)
-    * [Option: format](#option-format)
-        * [Markdown](#markdown)
-        * [reST](#rest)
-        * [Confluence](#confluence)
-        * [HTML](#html)
-        * [JSON](#json)
-        * [JSON LicenseFinder](#json-licensefinder)
-        * [CSV](#csv)
-        * [Plain Vertical](#plain-vertical)
-    * [Option: summary](#option-summary)
-    * [Option: output\-file](#option-output-file)
-    * [Option: filter\-strings](#option-filter-strings)
-    * [Option: filter\-code\-page](#option-filter-code-page)
-    * [Option: fail\-on](#option-fail-on)
-    * [Option: allow\-only](#option-allow-only)
+    * [Common options](#common-options)
+        * [Option: from](#option-from)
+        * [Option: order](#option-order)
+        * [Option: format](#option-format)
+            * [Markdown](#markdown)
+            * [reST](#rest)
+            * [Confluence](#confluence)
+            * [HTML](#html)
+            * [JSON](#json)
+            * [JSON LicenseFinder](#json-licensefinder)
+            * [CSV](#csv)
+            * [Plain Vertical](#plain-vertical)
+        * [Option: summary](#option-summary)
+        * [Option: output\-file](#option-output-file)
+        * [Option: ignore\-packages](#option-ignore-packages)
+    * [Format options](#format-options)
+        * [Option: with\-system](#option-with-system)
+        * [Option: with\-authors](#option-with-authors)
+        * [Option: with\-urls](#option-with-urls)
+        * [Option: with\-description](#option-with-description)
+        * [Option: with\-license\-file](#option-with-license-file)
+        * [Option: filter\-strings](#option-filter-strings)
+        * [Option: filter\-code\-page](#option-filter-code-page)
+    * [Verify options](#verify-options)
+        * [Option: fail\-on](#option-fail-on)
+        * [Option: allow\-only](#option-allow-only)
     * [More Information](#more-information)
 * [Dockerfile](#dockerfile)
 * [About UnicodeEncodeError](#about-unicodeencodeerror)
@@ -81,7 +84,9 @@ Execute the command with your venv (or virtualenv) environment.
 
 ## Command-Line Options
 
-### Option: from
+### Common options
+
+#### Option: from
 
 By default, this tool finds the license from [Trove Classifiers](https://pypi.org/classifiers/) or package Metadata. Some Python packages declare their license only in Trove Classifiers.
 
@@ -120,85 +125,7 @@ To list license information from both metadata and classifier, use `--from=all`.
 * The `mix` keyword is prepared as alias of `mixed`.
     * Default behavior in this tool
 
-### Option: with-system
-
-By default, system packages such as `pip` and `setuptools` are ignored.
-
-If you want to output all including system package, use the `--with-system` option.
-
-```bash
-(venv) $ pip-licenses --with-system
- Name          Version  License
- Django        2.0.2    BSD
- PTable        0.9.2    BSD (3 clause)
- pip           9.0.1    MIT
- pip-licenses  1.0.0    MIT License
- pytz          2017.3   MIT
- setuptools    38.5.0   UNKNOWN
-```
-
-### Option: with-authors
-
-When executed with the `--with-authors` option, output with author of the package.
-
-```bash
-(venv) $ pip-licenses --with-authors
- Name    Version  License  Author
- Django  2.0.2    BSD      Django Software Foundation
- pytz    2017.3   MIT      Stuart Bishop
-```
-
-### Option: with-urls
-
-For packages without Metadata, the license is output as `UNKNOWN`. To get more package information, use the `--with-urls` option.
-
-```bash
-(venv) $ pip-licenses --with-urls
- Name    Version  License  URL
- Django  2.0.2    BSD      https://www.djangoproject.com/
- pytz    2017.3   MIT      http://pythonhosted.org/pytz
-```
-
-### Option: with-description
-
-When executed with the `--with-description` option, output with short description of the package.
-
-```bash
-(venv) $ pip-licenses --with-description
- Name    Version  License  Description
- Django  2.0.2    BSD      A high-level Python Web framework that encourages rapid development and clean, pragmatic design.
- pytz    2017.3   MIT      World timezone definitions, modern and historical
-```
-
-### Option: with-license-file
-
-When executed with the `--with-license-file` option, output the location of the package's license file on disk and the full contents of that file. Due to the length of these fields, this option is best paired with `--format=json`.
-
-If you also want to output the file `NOTICE` distributed under Apache License etc., specify the `--with-notice-file` option additionally.
-
-**Note:** If you want to keep the license file path secret, specify `--no-license-path` option together.
-
-### Option: ignore-packages
-
-When executed with the `--ignore-packages` option, ignore the package specified by argument from list output.
-
-```bash
-(venv) $ pip-licenses --ignore-packages django
- Name  Version  License
- pytz  2017.3   MIT
-```
-
-Package names of arguments can be separated by spaces.
-
-```bash
-(venv) $ pip-licenses --with-system --ignore-packages django pip pip-licenses
- Name        Version  License
- PTable      0.9.2    BSD (3 clause)
- pytz        2017.3   MIT
- setuptools  38.5.0   UNKNOWN
-```
-
-### Option: order
+#### Option: order
 
 By default, it is ordered by package name.
 
@@ -208,11 +135,11 @@ If you give arguments to the `--order` option, you can output in other sorted or
 (venv) $ pip-licenses --order=license
 ```
 
-### Option: format
+#### Option: format
 
 By default, it is output to the `plain` format.
 
-#### Markdown
+##### Markdown
 
 When executed with the `--format=markdown` option, you can output list in markdown format. The `m` `md` keyword is prepared as alias of `markdown`.
 
@@ -231,7 +158,7 @@ When inserted in a markdown document, it is rendered as follows:
 | Django | 2.0.2   | BSD     |
 | pytz   | 2017.3  | MIT     |
 
-#### reST
+##### reST
 
 When executed with the `--format=rst` option, you can output list in "[Grid tables](http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#grid-tables)" of reStructuredText format. The `r` `rest` keyword is prepared as alias of `rst`.
 
@@ -246,7 +173,7 @@ When executed with the `--format=rst` option, you can output list in "[Grid tabl
 +--------+---------+---------+
 ```
 
-#### Confluence
+##### Confluence
 
 When executed with the `--format=confluence` option, you can output list in [Confluence (or JIRA) Wiki markup](https://confluence.atlassian.com/doc/confluence-wiki-markup-251003035.html#ConfluenceWikiMarkup-Tables) format. The `c` keyword is prepared as alias of `confluence`.
 
@@ -257,7 +184,7 @@ When executed with the `--format=confluence` option, you can output list in [Con
 | pytz   | 2017.3  | MIT     |
 ```
 
-#### HTML
+##### HTML
 
 When executed with the `--format=html` option, you can output list in HTML table format. The `h` keyword is prepared as alias of `html`.
 
@@ -282,7 +209,7 @@ When executed with the `--format=html` option, you can output list in HTML table
 </table>
 ```
 
-#### JSON
+##### JSON
 
 When executed with the `--format=json` option, you can output list in JSON format easily allowing post-processing. The `j` keyword is prepared as alias of `json`.
 
@@ -303,10 +230,9 @@ When executed with the `--format=json` option, you can output list in JSON forma
     "Version": "2017.3"
   }
 ]
-
 ```
 
-#### JSON LicenseFinder
+##### JSON LicenseFinder
 
 When executed with the `--format=json-license-finder` option, you can output list in JSON format that is identical to [LicenseFinder](https://github.com/pivotal/LicenseFinder). The `jlf` keyword is prepared as alias of `jlf`.
 This makes pip-licenses a drop-in replacement for LicenseFinder.
@@ -327,7 +253,7 @@ This makes pip-licenses a drop-in replacement for LicenseFinder.
 
 ```
 
-#### CSV
+##### CSV
 
 When executed with the `--format=csv` option, you can output list in quoted CSV format. Useful when you want to copy/paste the output to an Excel sheet.
 
@@ -338,7 +264,7 @@ When executed with the `--format=csv` option, you can output list in quoted CSV 
 "pytz","2017.3","MIT"
 ```
 
-#### Plain Vertical
+##### Plain Vertical
 
 When executed with the `--format=plain-vertical` option, you can output a simple plain vertical output that is similar to Angular CLI's
 [--extractLicenses flag](https://angular.io/cli/build#options). This format minimizes rightward drift.
@@ -371,7 +297,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
 
-### Option: summary
+#### Option: summary
 
 When executed with the `--summary` option, you can output a summary of each license.
 
@@ -384,7 +310,7 @@ When executed with the `--summary` option, you can output a summary of each lice
 
 **Note:** When using this option, only `--order=count` or `--order=license` has an effect for the `--order` option. And using `--with-authors` and `--with-urls` will be ignored.
 
-### Option: output\-file
+#### Option: output\-file
 
 When executed with the `--output-file` option, write the result to the path specified by the argument.
 
@@ -393,15 +319,99 @@ When executed with the `--output-file` option, write the result to the path spec
 created path: /tmp/output.rst
 ```
 
-### Option: filter\-strings
+#### Option: ignore-packages
+
+When executed with the `--ignore-packages` option, ignore the package specified by argument from list output.
+
+```bash
+(venv) $ pip-licenses --ignore-packages django
+ Name  Version  License
+ pytz  2017.3   MIT
+```
+
+Package names of arguments can be separated by spaces.
+
+```bash
+(venv) $ pip-licenses --with-system --ignore-packages django pip pip-licenses
+ Name        Version  License
+ PTable      0.9.2    BSD (3 clause)
+ pytz        2017.3   MIT
+ setuptools  38.5.0   UNKNOWN
+```
+
+
+### Format options
+
+#### Option: with-system
+
+By default, system packages such as `pip` and `setuptools` are ignored.
+
+If you want to output all including system package, use the `--with-system` option.
+
+```bash
+(venv) $ pip-licenses --with-system
+ Name          Version  License
+ Django        2.0.2    BSD
+ PTable        0.9.2    BSD (3 clause)
+ pip           9.0.1    MIT
+ pip-licenses  1.0.0    MIT License
+ pytz          2017.3   MIT
+ setuptools    38.5.0   UNKNOWN
+```
+
+#### Option: with-authors
+
+When executed with the `--with-authors` option, output with author of the package.
+
+```bash
+(venv) $ pip-licenses --with-authors
+ Name    Version  License  Author
+ Django  2.0.2    BSD      Django Software Foundation
+ pytz    2017.3   MIT      Stuart Bishop
+```
+
+#### Option: with-urls
+
+For packages without Metadata, the license is output as `UNKNOWN`. To get more package information, use the `--with-urls` option.
+
+```bash
+(venv) $ pip-licenses --with-urls
+ Name    Version  License  URL
+ Django  2.0.2    BSD      https://www.djangoproject.com/
+ pytz    2017.3   MIT      http://pythonhosted.org/pytz
+```
+
+#### Option: with-description
+
+When executed with the `--with-description` option, output with short description of the package.
+
+```bash
+(venv) $ pip-licenses --with-description
+ Name    Version  License  Description
+ Django  2.0.2    BSD      A high-level Python Web framework that encourages rapid development and clean, pragmatic design.
+ pytz    2017.3   MIT      World timezone definitions, modern and historical
+```
+
+#### Option: with-license-file
+
+When executed with the `--with-license-file` option, output the location of the package's license file on disk and the full contents of that file. Due to the length of these fields, this option is best paired with `--format=json`.
+
+If you also want to output the file `NOTICE` distributed under Apache License etc., specify the `--with-notice-file` option additionally.
+
+**Note:** If you want to keep the license file path secret, specify `--no-license-path` option together.
+
+#### Option: filter\-strings
 
 Some package data contains Unicode characters which might cause problems for certain output formats (in particular ReST tables). If this filter is enabled, all characters which cannot be encoded with a given code page (see `--filter-code-page`) will be removed from any input strings (e.g. package name, description).
 
-### Option: filter\-code\-page
+#### Option: filter\-code\-page
 
 If the input strings are filtered (see `--filter-strings`), you can specify the applied code page (default `latin-1`). A list of all available code pages can be found [codecs module document](https://docs.python.org/3/library/codecs.html#standard-encodings).
 
-### Option: fail\-on
+
+### Verify options
+
+#### Option: fail\-on
 
 Fail (exit with code 1) on the first occurrence of the licenses of the semicolon-separated list
 
@@ -425,7 +435,7 @@ $ echo $?
 $ pip-licenses --fail-on="Python Software Foundation License, MIT License;"
 ```
 
-### Option: allow\-only
+#### Option: allow\-only
 
 Fail (exit with code 1) on the first occurrence of the licenses not in the semicolon-separated list
 
@@ -443,6 +453,7 @@ $ pip-licenses | grep keyring
 # Both licenses must be specified together.
 $ pip-licenses --allow-only="Python Software Foundation License, MIT License;"
 ```
+
 
 ### More Information
 

--- a/piplicenses.py
+++ b/piplicenses.py
@@ -621,10 +621,12 @@ class CompatibleArgumentParser(argparse.ArgumentParser):
 def create_parser():
     parser = CompatibleArgumentParser(
         description=__summary__)
+
     parser.add_argument(
         '-v', '--version',
         action='version',
         version='%(prog)s ' + __version__)
+
     parser.add_argument(
         '--from',
         action='store', type=str,
@@ -632,6 +634,38 @@ def create_parser():
         help=('where to find license information\n'
               '"meta", "classifier, "mixed", "all"\n'
               'default: --from=mixed'))
+    parser.add_argument(
+        '-o', '--order',
+        action='store', type=str,
+        default='name', metavar='COL',
+        help=('order by column\n'
+              '"name", "license", "author", "url"\n'
+              'default: --order=name'))
+    parser.add_argument(
+        '-f', '--format',
+        action='store', type=str,
+        default='plain', metavar='STYLE',
+        help=('dump as set format style\n'
+              '"plain", "plain-vertical" "markdown", "rst", \n'
+              '"confluence", "html", "json", \n'
+              '"json-license-finder",  "csv"\n'
+              'default: --format=plain'))
+    parser.add_argument(
+        '--summary',
+        action='store_true',
+        default=False,
+        help='dump summary of each license')
+    parser.add_argument(
+        '--output-file',
+        action='store', type=str,
+        help='save license list to file')
+    parser.add_argument(
+        '-i', '--ignore-packages',
+        action='store', type=str,
+        nargs='+', metavar='PKG',
+        default=[],
+        help='ignore package name in dumped list')
+
     parser.add_argument(
         '-s', '--with-system',
         action='store_true',
@@ -671,28 +705,6 @@ def create_parser():
         help='when specified together with option -l, '
              'dump with location of license file and contents')
     parser.add_argument(
-        '-i', '--ignore-packages',
-        action='store', type=str,
-        nargs='+', metavar='PKG',
-        default=[],
-        help='ignore package name in dumped list')
-    parser.add_argument(
-        '-o', '--order',
-        action='store', type=str,
-        default='name', metavar='COL',
-        help=('order by column\n'
-              '"name", "license", "author", "url"\n'
-              'default: --order=name'))
-    parser.add_argument(
-        '-f', '--format',
-        action='store', type=str,
-        default='plain', metavar='STYLE',
-        help=('dump as set format style\n'
-              '"plain", "plain-vertical" "markdown", "rst", \n'
-              '"confluence", "html", "json", \n'
-              '"json-license-finder",  "csv"\n'
-              'default: --format=plain'))
-    parser.add_argument(
         '--filter-strings',
         action="store_true",
         default=False,
@@ -702,15 +714,7 @@ def create_parser():
         action="store", type=str,
         default="latin1",
         help=('specify code page for filtering'))
-    parser.add_argument(
-        '--summary',
-        action='store_true',
-        default=False,
-        help='dump summary of each license')
-    parser.add_argument(
-        '--output-file',
-        action='store', type=str,
-        help='save license list to file')
+
     parser.add_argument(
         '--fail-on',
         action='store', type=str,

--- a/piplicenses.py
+++ b/piplicenses.py
@@ -32,32 +32,30 @@ import glob
 import os
 import sys
 from collections import Counter
-from enum import Enum, auto
 from email import message_from_string
 from email.parser import FeedParser
+from enum import Enum, auto
 from functools import partial
-from typing import Optional, List, Text
+from typing import List, Optional, Text
 
 try:
     from pip._internal.utils.misc import get_installed_distributions
 except ImportError:  # pragma: no cover
     from pip import get_installed_distributions
+
 from prettytable import PrettyTable
+
 try:
-    from prettytable.prettytable import (
-        ALL as RULE_ALL,
-        FRAME as RULE_FRAME,
-        HEADER as RULE_HEADER,
-        NONE as RULE_NONE,
-    )
+    from prettytable.prettytable import ALL as RULE_ALL
+    from prettytable.prettytable import FRAME as RULE_FRAME
+    from prettytable.prettytable import HEADER as RULE_HEADER
+    from prettytable.prettytable import NONE as RULE_NONE
     PTABLE = True
 except ImportError:  # pragma: no cover
-    from prettytable import (
-        ALL as RULE_ALL,
-        FRAME as RULE_FRAME,
-        HEADER as RULE_HEADER,
-        NONE as RULE_NONE,
-    )
+    from prettytable import ALL as RULE_ALL
+    from prettytable import FRAME as RULE_FRAME
+    from prettytable import HEADER as RULE_HEADER
+    from prettytable import NONE as RULE_NONE
     PTABLE = False
 
 open = open  # allow monkey patching

--- a/piplicenses.py
+++ b/piplicenses.py
@@ -543,7 +543,6 @@ def create_warn_string(args):
 
 
 class CompatibleArgumentParser(argparse.ArgumentParser):
-
     def parse_args(self, args=None, namespace=None):
         args = super(CompatibleArgumentParser, self).parse_args(args,
                                                                 namespace)
@@ -622,91 +621,108 @@ class CompatibleArgumentParser(argparse.ArgumentParser):
 def create_parser():
     parser = CompatibleArgumentParser(
         description=__summary__)
-    parser.add_argument('-v', '--version',
-                        action='version',
-                        version='%(prog)s ' + __version__)
-    parser.add_argument('--from',
-                        action='store', type=str,
-                        default='mixed', metavar='SOURCE',
-                        help=('where to find license information\n'
-                              '"meta", "classifier, "mixed", "all"\n'
-                              'default: --from=mixed'))
-    parser.add_argument('-s', '--with-system',
-                        action='store_true',
-                        default=False,
-                        help='dump with system packages')
-    parser.add_argument('-a', '--with-authors',
-                        action='store_true',
-                        default=False,
-                        help='dump with package authors')
-    parser.add_argument('-u', '--with-urls',
-                        action='store_true',
-                        default=False,
-                        help='dump with package urls')
-    parser.add_argument('-d', '--with-description',
-                        action='store_true',
-                        default=False,
-                        help='dump with short package description')
-    parser.add_argument('-l', '--with-license-file',
-                        action='store_true',
-                        default=False,
-                        help='dump with location of license file and '
-                             'contents, most useful with JSON output')
-    parser.add_argument('--no-license-path',
-                        action='store_true',
-                        default=False,
-                        help='when specified together with option -l, '
-                             'suppress location of license file output')
-    parser.add_argument('--with-notice-file',
-                        action='store_true',
-                        default=False,
-                        help='when specified together with option -l, '
-                             'dump with location of license file and contents')
-    parser.add_argument('-i', '--ignore-packages',
-                        action='store', type=str,
-                        nargs='+', metavar='PKG',
-                        default=[],
-                        help='ignore package name in dumped list')
-    parser.add_argument('-o', '--order',
-                        action='store', type=str,
-                        default='name', metavar='COL',
-                        help=('order by column\n'
-                              '"name", "license", "author", "url"\n'
-                              'default: --order=name'))
-    parser.add_argument('-f', '--format',
-                        action='store', type=str,
-                        default='plain', metavar='STYLE',
-                        help=('dump as set format style\n'
-                              '"plain", "plain-vertical" "markdown", "rst", \n'
-                              '"confluence", "html", "json", \n'
-                              '"json-license-finder",  "csv"\n'
-                              'default: --format=plain'))
-    parser.add_argument('--filter-strings',
-                        action="store_true",
-                        default=False,
-                        help=('filter input according to code page'))
-    parser.add_argument('--filter-code-page',
-                        action="store", type=str,
-                        default="latin1",
-                        help=('specify code page for filtering'))
-    parser.add_argument('--summary',
-                        action='store_true',
-                        default=False,
-                        help='dump summary of each license')
-    parser.add_argument('--output-file',
-                        action='store', type=str,
-                        help='save license list to file')
-    parser.add_argument('--fail-on',
-                        action='store', type=str,
-                        default=None,
-                        help='fail (exit with code 1) on the first occurrence '
-                             'of the licenses of the semicolon-separated list')
-    parser.add_argument('--allow-only',
-                        action='store', type=str,
-                        default=None,
-                        help='fail (exit with code 1) on the first occurrence '
-                             'of the licenses not in the semicolon-separated '
-                             'list')
+    parser.add_argument(
+        '-v', '--version',
+        action='version',
+        version='%(prog)s ' + __version__)
+    parser.add_argument(
+        '--from',
+        action='store', type=str,
+        default='mixed', metavar='SOURCE',
+        help=('where to find license information\n'
+              '"meta", "classifier, "mixed", "all"\n'
+              'default: --from=mixed'))
+    parser.add_argument(
+        '-s', '--with-system',
+        action='store_true',
+        default=False,
+        help='dump with system packages')
+    parser.add_argument(
+        '-a', '--with-authors',
+        action='store_true',
+        default=False,
+        help='dump with package authors')
+    parser.add_argument(
+        '-u', '--with-urls',
+        action='store_true',
+        default=False,
+        help='dump with package urls')
+    parser.add_argument(
+        '-d', '--with-description',
+        action='store_true',
+        default=False,
+        help='dump with short package description')
+    parser.add_argument(
+        '-l', '--with-license-file',
+        action='store_true',
+        default=False,
+        help='dump with location of license file and '
+             'contents, most useful with JSON output')
+    parser.add_argument(
+        '--no-license-path',
+        action='store_true',
+        default=False,
+        help='when specified together with option -l, '
+             'suppress location of license file output')
+    parser.add_argument(
+        '--with-notice-file',
+        action='store_true',
+        default=False,
+        help='when specified together with option -l, '
+             'dump with location of license file and contents')
+    parser.add_argument(
+        '-i', '--ignore-packages',
+        action='store', type=str,
+        nargs='+', metavar='PKG',
+        default=[],
+        help='ignore package name in dumped list')
+    parser.add_argument(
+        '-o', '--order',
+        action='store', type=str,
+        default='name', metavar='COL',
+        help=('order by column\n'
+              '"name", "license", "author", "url"\n'
+              'default: --order=name'))
+    parser.add_argument(
+        '-f', '--format',
+        action='store', type=str,
+        default='plain', metavar='STYLE',
+        help=('dump as set format style\n'
+              '"plain", "plain-vertical" "markdown", "rst", \n'
+              '"confluence", "html", "json", \n'
+              '"json-license-finder",  "csv"\n'
+              'default: --format=plain'))
+    parser.add_argument(
+        '--filter-strings',
+        action="store_true",
+        default=False,
+        help=('filter input according to code page'))
+    parser.add_argument(
+        '--filter-code-page',
+        action="store", type=str,
+        default="latin1",
+        help=('specify code page for filtering'))
+    parser.add_argument(
+        '--summary',
+        action='store_true',
+        default=False,
+        help='dump summary of each license')
+    parser.add_argument(
+        '--output-file',
+        action='store', type=str,
+        help='save license list to file')
+    parser.add_argument(
+        '--fail-on',
+        action='store', type=str,
+        default=None,
+        help='fail (exit with code 1) on the first occurrence '
+             'of the licenses of the semicolon-separated list')
+    parser.add_argument(
+        '--allow-only',
+        action='store', type=str,
+        default=None,
+        help='fail (exit with code 1) on the first occurrence '
+             'of the licenses not in the semicolon-separated list')
 
     return parser
 

--- a/piplicenses.py
+++ b/piplicenses.py
@@ -622,26 +622,30 @@ def create_parser():
     parser = CompatibleArgumentParser(
         description=__summary__)
 
+    common_options = parser.add_argument_group('Common options')
+    format_options = parser.add_argument_group('Format options')
+    verify_options = parser.add_argument_group('Verify options')
+
     parser.add_argument(
         '-v', '--version',
         action='version',
         version='%(prog)s ' + __version__)
 
-    parser.add_argument(
+    common_options.add_argument(
         '--from',
         action='store', type=str,
         default='mixed', metavar='SOURCE',
         help=('where to find license information\n'
               '"meta", "classifier, "mixed", "all"\n'
               'default: --from=mixed'))
-    parser.add_argument(
+    common_options.add_argument(
         '-o', '--order',
         action='store', type=str,
         default='name', metavar='COL',
         help=('order by column\n'
               '"name", "license", "author", "url"\n'
               'default: --order=name'))
-    parser.add_argument(
+    common_options.add_argument(
         '-f', '--format',
         action='store', type=str,
         default='plain', metavar='STYLE',
@@ -650,78 +654,78 @@ def create_parser():
               '"confluence", "html", "json", \n'
               '"json-license-finder",  "csv"\n'
               'default: --format=plain'))
-    parser.add_argument(
+    common_options.add_argument(
         '--summary',
         action='store_true',
         default=False,
         help='dump summary of each license')
-    parser.add_argument(
+    common_options.add_argument(
         '--output-file',
         action='store', type=str,
         help='save license list to file')
-    parser.add_argument(
+    common_options.add_argument(
         '-i', '--ignore-packages',
         action='store', type=str,
         nargs='+', metavar='PKG',
         default=[],
         help='ignore package name in dumped list')
 
-    parser.add_argument(
+    format_options.add_argument(
         '-s', '--with-system',
         action='store_true',
         default=False,
         help='dump with system packages')
-    parser.add_argument(
+    format_options.add_argument(
         '-a', '--with-authors',
         action='store_true',
         default=False,
         help='dump with package authors')
-    parser.add_argument(
+    format_options.add_argument(
         '-u', '--with-urls',
         action='store_true',
         default=False,
         help='dump with package urls')
-    parser.add_argument(
+    format_options.add_argument(
         '-d', '--with-description',
         action='store_true',
         default=False,
         help='dump with short package description')
-    parser.add_argument(
+    format_options.add_argument(
         '-l', '--with-license-file',
         action='store_true',
         default=False,
         help='dump with location of license file and '
              'contents, most useful with JSON output')
-    parser.add_argument(
+    format_options.add_argument(
         '--no-license-path',
         action='store_true',
         default=False,
         help='when specified together with option -l, '
              'suppress location of license file output')
-    parser.add_argument(
+    format_options.add_argument(
         '--with-notice-file',
         action='store_true',
         default=False,
         help='when specified together with option -l, '
              'dump with location of license file and contents')
-    parser.add_argument(
+    format_options.add_argument(
         '--filter-strings',
         action="store_true",
         default=False,
         help=('filter input according to code page'))
-    parser.add_argument(
+    format_options.add_argument(
         '--filter-code-page',
         action="store", type=str,
         default="latin1",
         help=('specify code page for filtering'))
 
-    parser.add_argument(
+    verify_options.add_argument(
         '--fail-on',
         action='store', type=str,
         default=None,
         help='fail (exit with code 1) on the first occurrence '
              'of the licenses of the semicolon-separated list')
-    parser.add_argument(
+    verify_options.add_argument(
         '--allow-only',
         action='store', type=str,
         default=None,

--- a/piplicenses.py
+++ b/piplicenses.py
@@ -584,22 +584,30 @@ class CustomHelpFormatter(argparse.HelpFormatter):  # pragma: no cover
 
 class CompatibleArgumentParser(argparse.ArgumentParser):
     def parse_args(self, args=None, namespace=None):
-        args = super(CompatibleArgumentParser, self).parse_args(args,
-                                                                namespace)
-        self._check_code_page(args.filter_code_page)
-
+        args = super().parse_args(args, namespace)
+        self._verify_args(args)
         return args
 
-    @staticmethod
-    def _check_code_page(code_page):
+    def _verify_args(self, args):
+        if args.with_license_file is False and (
+                args.no_license_path is True or
+                args.with_notice_file is True):
+            self.error(
+                "'--no-license-path' and '--with-notice-file' require "
+                "the '--with-license-file' option to be set")
+        if args.filter_strings is False and \
+                args.filter_code_page != 'latin1':
+            self.error(
+                "'--filter-code-page' requires the '--filter-strings' "
+                "option to be set")
         try:
-            codecs.lookup(code_page)
+            codecs.lookup(args.filter_code_page)
         except LookupError:
-            print(("error: invalid code page '%s' given for "
-                   "--filter-code-page;\n"
-                   "       check https://docs.python.org/3/library/"
-                   "codecs.html for valid code pages") % code_page)
-            sys.exit(1)
+            self.error(
+                "invalid code page '%s' given for '--filter-code-page, "
+                "check https://docs.python.org/3/library/codecs.html"
+                "#standard-encodings for valid code pages"
+                % args.filter_code_page)
 
 
 class NoValueEnum(Enum):

--- a/piplicenses.py
+++ b/piplicenses.py
@@ -566,6 +566,12 @@ class CustomHelpFormatter(argparse.HelpFormatter):  # pragma: no cover
             self._dedent()
         return help_str
 
+    def _expand_help(self, action: argparse.Action) -> str:
+        if isinstance(action.default, Enum):
+            default_value = enum_key_to_value(action.default)
+            return self._get_help_string(action) % {'default': default_value}
+        return super()._expand_help(action)
+
     def _split_lines(self, text: Text, width: int) -> List[str]:
         separator_pos = text[:3].find('|')
         if separator_pos != -1:
@@ -628,8 +634,12 @@ class FormatArg(NoValueEnum):
     CSV = auto()
 
 
-def format_arg_option(value: str) -> str:
+def value_to_enum_key(value: str) -> str:
     return value.replace('-', '_').upper()
+
+
+def enum_key_to_value(enum_key: Enum) -> str:
+    return enum_key.name.replace('_', '-').lower()
 
 
 def choices_from_enum(enum_cls: NoValueEnum) -> List[str]:
@@ -652,7 +662,7 @@ class SelectAction(argparse.Action):
         option_string: Optional[Text] = None,
     ) -> None:
         enum_cls = map_dest_to_enum[self.dest]
-        values = format_arg_option(values)
+        values = value_to_enum_key(values)
         setattr(namespace, self.dest, getattr(enum_cls, values))
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,3 +49,10 @@ test = pytest
 
 [tool:pytest]
 addopts = --pycodestyle -v --cov --cov-report term-missing
+
+[tool:isort]
+# https://github.com/timothycrosley/isort
+multi_line_output = 4
+line_length = 72
+known_first_party =
+    piplicenses

--- a/test_piplicenses.py
+++ b/test_piplicenses.py
@@ -7,24 +7,21 @@ import unittest
 from email import message_from_string
 from enum import Enum, auto
 
+import docutils.frontend
 import docutils.parsers.rst
 import docutils.utils
-import docutils.frontend
 import pytest
 from _pytest.capture import CaptureFixture
 
 import piplicenses
-from piplicenses import (FromArg, __pkgname__, create_parser, output_colored,
-                         create_licenses_table, get_output_fields, get_sortby,
-                         factory_styled_table_with_args, create_warn_string,
-                         find_license_from_classifier, create_output_string,
-                         select_license_by_source, save_if_needs,
-                         RULE_ALL, RULE_FRAME, RULE_HEADER, RULE_NONE,
-                         DEFAULT_OUTPUT_FIELDS, SYSTEM_PACKAGES,
-                         LICENSE_UNKNOWN,
-                         CompatibleArgumentParser, value_to_enum_key,
-                         enum_key_to_value)
-
+from piplicenses import (
+    DEFAULT_OUTPUT_FIELDS, LICENSE_UNKNOWN, RULE_ALL, RULE_FRAME,
+    RULE_HEADER, RULE_NONE, SYSTEM_PACKAGES, CompatibleArgumentParser,
+    FromArg, __pkgname__, create_licenses_table, create_output_string,
+    create_parser, create_warn_string, enum_key_to_value,
+    factory_styled_table_with_args, find_license_from_classifier,
+    get_output_fields, get_sortby, output_colored, save_if_needs,
+    select_license_by_source, value_to_enum_key)
 
 UNICODE_APPENDIX = ""
 with open('tests/fixtures/unicode_characters.txt', encoding='utf-8') as f:

--- a/test_piplicenses.py
+++ b/test_piplicenses.py
@@ -11,7 +11,7 @@ import docutils.utils
 import docutils.frontend
 
 import piplicenses
-from piplicenses import (__pkgname__, create_parser, output_colored,
+from piplicenses import (FromArg, __pkgname__, create_parser, output_colored,
                          create_licenses_table, get_output_fields, get_sortby,
                          factory_styled_table_with_args, create_warn_string,
                          find_license_from_classifier, create_output_string,
@@ -203,22 +203,22 @@ class TestGetLicenses(CommandLineTestCase):
 
     def test_select_license_by_source(self):
         self.assertEqual('MIT License',
-                         select_license_by_source('classifier',
+                         select_license_by_source(FromArg.CLASSIFIER,
                                                   ['MIT License'],
                                                   'MIT'))
 
         self.assertEqual(LICENSE_UNKNOWN,
-                         select_license_by_source('classifier',
+                         select_license_by_source(FromArg.CLASSIFIER,
                                                   [],
                                                   'MIT'))
 
         self.assertEqual('MIT License',
-                         select_license_by_source('mixed',
+                         select_license_by_source(FromArg.MIXED,
                                                   ['MIT License'],
                                                   'MIT'))
 
         self.assertEqual('MIT',
-                         select_license_by_source('mixed',
+                         select_license_by_source(FromArg.MIXED,
                                                   [],
                                                   'MIT'))
 


### PR DESCRIPTION
Some improvements to the argument parser. This PR greatly improves the readability of the help command and introduces `Enums` for arguments.

**Current help text**
<img width="860" alt="Screen Shot 2021-01-19 at 00 54 59" src="https://user-images.githubusercontent.com/30130371/104972101-1341c580-59f1-11eb-8601-068ad68db310.png">


**Changes**
- `\n` in help strings are now rendered correctly
- Added argument groups and rearranged argument positions
- Updated readme to match changes
- Updated `max_help_position` to avoid unnecessary line breaks
- Added choices as additional help for `from`, `order` and `format`
- Added enums for `from`, `order` and `format`

<img width="858" alt="Screen Shot 2021-01-19 at 00 39 34" src="https://user-images.githubusercontent.com/30130371/104971365-d543a200-59ee-11eb-8afa-e9e654d27e79.png">

<img width="941" alt="Screen Shot 2021-01-19 at 00 57 35" src="https://user-images.githubusercontent.com/30130371/104972268-89dec300-59f1-11eb-9019-a8def2cf832d.png">


--

I've split these changes into multiple commits to make reviewing them a bit easier.

On a related note, what is your opinion to `squash merge` for PRs? Although it might seem counterintuitive at first, I think it makes the git log much easier to read and the Github integration is better. The squash commit message includes the PR number which will be automatically be linked (for `git blame`).