### PR TITLE
Fix license summary

### DIFF
--- a/piplicenses.py
+++ b/piplicenses.py
@@ -283,7 +283,9 @@ def create_licenses_table(
 
 
 def create_summary_table(args: "CustomNamespace"):
-    counts = Counter(pkg['license'] for pkg in get_packages(args))
+    counts = Counter(select_license_by_source(
+        args.from_, pkg['license_classifier'], pkg['license'])
+        for pkg in get_packages(args))
 
     table = factory_styled_table_with_args(args, SUMMARY_FIELD_NAMES)
     for license, count in counts.items():


### PR DESCRIPTION
In #86 I changed the way licenses are handled to allow the `--from=all` option. That meant however that the license classifier wasn't written into the package metadata anymore if the wasn't any.

This PR uses `select_license_by_source` to correctly identify which license should be counted.

Closes #93 

--

Regarding the `dev` branch: This should definitely be address there as well. However since the structure changed, a rebase on its own won't do it. I would suggest that I open and additional PR just for it once the `dev` branch is rebased correctly.