### PR TITLE
Verify multiple licenses individually

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,6 @@ docker/*
 
 # macOS
 .DS_Store
+
+# IDE
+.idea

--- a/README.md
+++ b/README.md
@@ -439,19 +439,16 @@ If `--from=all`, the option will apply to the metadata license field.
 ```
 (venv) $ pip-licenses --fail-on="MIT License;BSD License"
 ```
-**Note:** When using this option, pip-licenses looks for an exact match. Packages with multiple licenses will only fail if that license combination is included in the list. For example:
+**Note:** Packages with multiple licenses will fail if at least one license is included in the fail-on list. For example:
 ```
-# keyring library has 2 licenses, separated by a comma
+# keyring library has 2 licenses
 $ pip-licenses | grep keyring
  keyring             21.4.0     Python Software Foundation License, MIT License
 
-# If just "Python Software Foundation License" is specified, it will succeed.
+# If just "Python Software Foundation License" is specified, it will fail.
 $ pip-licenses --fail-on="Python Software Foundation License;"
 $ echo $?
-0
-
-# Both licenses must be specified together.
-$ pip-licenses --fail-on="Python Software Foundation License, MIT License;"
+1
 ```
 
 #### Option: allow\-only
@@ -463,14 +460,19 @@ If `--from=all`, the option will apply to the metadata license field.
 ```
 (venv) $ pip-licenses --allow-only="MIT License;BSD License"
 ```
-**Note:** When using this option, pip-licenses looks for an exact match. Packages with multiple licenses will only be allowed if that license combination is included in the list. For example:
+**Note:** Packages with multiple licenses will only be allowed if all the licenses are included in the allow-only list. For example:
 ```
-# keyring library has 2 licenses, separated by a comma
+# keyring library has 2 licenses
 $ pip-licenses | grep keyring
  keyring             21.4.0     Python Software Foundation License, MIT License
 
-# Both licenses must be specified together.
-$ pip-licenses --allow-only="Python Software Foundation License, MIT License;"
+# Both licenses must be specified (order does not matter).
+$ pip-licenses --allow-only="Python Software Foundation License;MIT License;"
+
+# If any one license is missing, the check will fail.
+$ pip-licenses --allow-only="Python Software Foundation License"
+$ echo $?
+1
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The mixed mode (`--from=mixed`) of this tool works well and looks for licenses.
 
 In mixed mode, it first tries to look for licenses in the Trove Classifiers. When not found in the Trove Classifiers, the license declared in Metadata is displayed.
 
-If you want to looks only in metadata, use `--from=meta`. If you want to looks only in Trove Classifiers, use `--from=classifier`.
+If you want to look only in metadata, use `--from=meta`. If you want to look only in Trove Classifiers, use `--from=classifier`.
 
 To list license information from both metadata and classifier, use `--from=all`.
 
@@ -436,7 +436,7 @@ Fail (exit with code 1) on the first occurrence of the licenses of the semicolon
 
 If `--from=all`, the option will apply to the metadata license field.
 
-```
+```bash
 (venv) $ pip-licenses --fail-on="MIT License;BSD License"
 ```
 **Note:** Packages with multiple licenses will fail if at least one license is included in the fail-on list. For example:
@@ -453,24 +453,28 @@ $ echo $?
 
 #### Option: allow\-only
 
-Fail (exit with code 1) on the first occurrence of the licenses not in the semicolon-separated list
+Fail (exit with code 1) if none of the package licenses are in the semicolon-separated list
 
 If `--from=all`, the option will apply to the metadata license field.
 
-```
+```bash
 (venv) $ pip-licenses --allow-only="MIT License;BSD License"
 ```
-**Note:** Packages with multiple licenses will only be allowed if all the licenses are included in the allow-only list. For example:
+**Note:** Packages with multiple licenses will only be allowed if at least one license is included in the allow-only list. For example:
 ```
 # keyring library has 2 licenses
-$ pip-licenses | grep keyring
- keyring             21.4.0     Python Software Foundation License, MIT License
+$ pip-licenses --package keyring
+ Name     Version  License                                         
+ keyring  23.0.1   MIT License; Python Software Foundation License
 
-# Both licenses must be specified (order does not matter).
-$ pip-licenses --allow-only="Python Software Foundation License;MIT License;"
+# One or both licenses must be specified (order does not matter). Following checks will pass:
+$ pip-licenses --package keyring --allow-only="MIT License"
+$ pip-licenses --package keyring --allow-only="BSD License;MIT License"
+$ pip-licenses --package keyring --allow-only="Python Software Foundation License"
+$ pip-licenses --package keyring --allow-only="Python Software Foundation License;MIT License"
 
-# If any one license is missing, the check will fail.
-$ pip-licenses --allow-only="Python Software Foundation License"
+# If none of the license in the allow list match, the check will fail.
+$ pip-licenses --package keyring  --allow-only="BSD License"
 $ echo $?
 1
 ```

--- a/piplicenses.py
+++ b/piplicenses.py
@@ -237,34 +237,33 @@ def get_packages(args: "CustomNamespace"):
 
         pkg_info = get_pkg_info(pkg)
 
-        license_name = select_license_by_source(
+        license_names = select_license_by_source(
             args.from_,
             pkg_info['license_classifier'],
             pkg_info['license'])
 
-        license_names = set(license_name.split(', '))
-
         if fail_on_licenses:
             failed_licenses = license_names.intersection(fail_on_licenses)
             if failed_licenses:
-                sys.stderr.write("fail-on license {} was found for package "
-                                 "{}:{}".format(
-                                    ', '.join(failed_licenses),
-                                    pkg_info['name'],
-                                    pkg_info['version'])
-                                 )
+                sys.stderr.write(
+                    "fail-on license {} was found for package "
+                    "{}:{}".format(
+                        '; '.join(failed_licenses),
+                        pkg_info['name'],
+                        pkg_info['version'])
+                )
                 sys.exit(1)
 
         if allow_only_licenses:
-            missing_licenses = license_names.difference(allow_only_licenses)
-            if missing_licenses:
+            uncommon_licenses = license_names.difference(allow_only_licenses)
+            if len(uncommon_licenses) == len(license_names):
                 sys.stderr.write(
                     "license {} not in allow-only licenses was found"
                     " for package {}:{}".format(
-                       ', '.join(missing_licenses),
-                       pkg_info['name'],
-                       pkg_info['version'])
-                    )
+                        '; '.join(uncommon_licenses),
+                        pkg_info['name'],
+                        pkg_info['version'])
+                )
                 sys.exit(1)
 
         yield pkg_info
@@ -278,11 +277,12 @@ def create_licenses_table(
         row = []
         for field in output_fields:
             if field == 'License':
-                license_str = select_license_by_source(
+                license_set = select_license_by_source(
                     args.from_, pkg['license_classifier'], pkg['license'])
+                license_str = '; '.join(license_set)
                 row.append(license_str)
             elif field == 'License-Classifier':
-                row.append(', '.join(pkg['license_classifier'])
+                row.append('; '.join(pkg['license_classifier'])
                            or LICENSE_UNKNOWN)
             elif field.lower() in pkg:
                 row.append(pkg[field.lower()])
@@ -294,8 +294,9 @@ def create_licenses_table(
 
 
 def create_summary_table(args: "CustomNamespace"):
-    counts = Counter(select_license_by_source(
-        args.from_, pkg['license_classifier'], pkg['license'])
+    counts = Counter(
+        '; '.join(select_license_by_source(
+            args.from_, pkg['license_classifier'], pkg['license']))
         for pkg in get_packages(args))
 
     table = factory_styled_table_with_args(args, SUMMARY_FIELD_NAMES)
@@ -463,12 +464,12 @@ def find_license_from_classifier(message):
 
 
 def select_license_by_source(from_source, license_classifier, license_meta):
-    license_classifier_str = ', '.join(license_classifier) or LICENSE_UNKNOWN
+    license_classifier_set = set(license_classifier) or {LICENSE_UNKNOWN}
     if (from_source == FromArg.CLASSIFIER or
             from_source == FromArg.MIXED and len(license_classifier) > 0):
-        return license_classifier_str
+        return license_classifier_set
     else:
-        return license_meta
+        return {license_meta}
 
 
 def get_output_fields(args: "CustomNamespace"):

--- a/test_piplicenses.py
+++ b/test_piplicenses.py
@@ -203,22 +203,22 @@ class TestGetLicenses(CommandLineTestCase):
                          find_license_from_classifier(message))
 
     def test_select_license_by_source(self):
-        self.assertEqual('MIT License',
+        self.assertEqual({'MIT License'},
                          select_license_by_source(FromArg.CLASSIFIER,
                                                   ['MIT License'],
                                                   'MIT'))
 
-        self.assertEqual(LICENSE_UNKNOWN,
+        self.assertEqual({LICENSE_UNKNOWN},
                          select_license_by_source(FromArg.CLASSIFIER,
                                                   [],
                                                   'MIT'))
 
-        self.assertEqual('MIT License',
+        self.assertEqual({'MIT License'},
                          select_license_by_source(FromArg.MIXED,
                                                   ['MIT License'],
                                                   'MIT'))
 
-        self.assertEqual('MIT',
+        self.assertEqual({'MIT'},
                          select_license_by_source(FromArg.MIXED,
                                                   [],
                                                   'MIT'))

--- a/test_piplicenses.py
+++ b/test_piplicenses.py
@@ -599,7 +599,7 @@ class MockStdStream(object):
         self.printed = p
 
 
-def test_output_file_sccess(monkeypatch):
+def test_output_file_success(monkeypatch):
     def mocked_open(*args, **kwargs):
         import tempfile
         return tempfile.TemporaryFile('w')
@@ -649,11 +649,8 @@ def test_allow_only(monkeypatch):
         "BSD License",
         "Apache Software License",
         "Mozilla Public License 2.0 (MPL 2.0)",
-        "MIT License, Mozilla Public License 2.0 (MPL 2.0)",
-        "Apache Software License, BSD License",
-        "Python Software Foundation License, MIT License",
-        "Public Domain, Python Software Foundation License, BSD License, "
-        "GNU General Public License (GPL)",
+        "Python Software Foundation License",
+        "Public Domain",
         "GNU General Public License (GPL)",
         "GNU Library or Lesser General Public License (LGPL)",
     )


### PR DESCRIPTION
* Changed behavior of `allow-only` and `fail-on` flags. Now you do not
  need to specify exact combinations of multiple licenses.
* Updated Readme and tests