### PR TITLE
Ignore spaces around fail-on and allow-only parameters

### DIFF
--- a/piplicenses.py
+++ b/piplicenses.py
@@ -217,11 +217,11 @@ def get_packages(args: "CustomNamespace"):
 
     fail_on_licenses = set()
     if args.fail_on:
-        fail_on_licenses = set(args.fail_on.split(";"))
+        fail_on_licenses = set(map(str.strip, args.fail_on.split(";")))
 
     allow_only_licenses = set()
     if args.allow_only:
-        allow_only_licenses = set(args.allow_only.split(";"))
+        allow_only_licenses = set(map(str.strip, args.allow_only.split(";")))
 
     for pkg in pkgs:
         pkg_name = pkg.project_name


### PR DESCRIPTION
In its current format, this tool will always fail if there are spaces around the semicolons in the fail-on or allow-only parameters, such as `License 1; License 2`. This is due to the second license to be parsed as `" License 2"` with a space at the beginning, not matching `"License 2"`.

This can be problematic in YAML-based CI setups for example, where you wouldn't be able to add line breaks inside the command without adding additional spaces, which is the problem I am currently facing.

This commit solves that by passing arguments through `str.strip`.