### PR TITLE
Fix license classifier check

### DIFF
--- a/piplicenses.py
+++ b/piplicenses.py
@@ -437,9 +437,11 @@ def find_license_from_classifier(classifiers):
 
 
 def select_license_by_source(from_source, license_classifier, license_meta):
+    if isinstance(license_classifier, str):
+        license_classifier = [license_classifier]
     license_classifier_set = set(license_classifier) or {LICENSE_UNKNOWN}
     if (from_source == FromArg.CLASSIFIER or
-            from_source == FromArg.MIXED and len(license_classifier) > 0):
+            from_source == FromArg.MIXED and len(license_classifier) > 0 and LICENSE_UNKNOWN not in license_classifier):
         return license_classifier_set
     else:
         return {license_meta}


### PR DESCRIPTION
Without this patch [starlette-exporter](https://github.com/stephenhillier/starlette_exporter) shows a messed up `UNKNOWN` license:
```
| Name               | Version   | License                              |
|--------------------|-----------|--------------------------------------|
| starlette-exporter | 0.14.0    | K; N; O; U; W                        |
```
Patched:
```
| Name               | Version   | License                              |
|--------------------|-----------|--------------------------------------|
| starlette-exporter | 0.14.0    | Apache License 2.0                   |
```