### PR TITLE
Escape unicode output (to e.g. &#123;) in the html output

### DIFF
--- a/piplicenses.py
+++ b/piplicenses.py
@@ -540,7 +540,8 @@ def create_output_string(args: CustomNamespace) -> str:
     sortby = get_sortby(args)
 
     if args.format_ == FormatArg.HTML:
-        return table.get_html_string(fields=output_fields, sortby=sortby)
+        html = table.get_html_string(fields=output_fields, sortby=sortby)
+        return html.encode('ascii', errors='xmlcharrefreplace').decode('ascii')
     else:
         return table.get_string(fields=output_fields, sortby=sortby)
 

--- a/piplicenses.py
+++ b/piplicenses.py
@@ -541,7 +541,7 @@ def create_output_string(args: CustomNamespace) -> str:
 
     if args.format_ == FormatArg.HTML:
         html = table.get_html_string(fields=output_fields, sortby=sortby)
-        return html.encode('ascii', errors='xmlcharrefreplace').decode('ascii')
+        return html.encode("ascii", errors="xmlcharrefreplace").decode("ascii")
     else:
         return table.get_string(fields=output_fields, sortby=sortby)
 

--- a/test_piplicenses.py
+++ b/test_piplicenses.py
@@ -538,11 +538,12 @@ class TestGetLicenses(CommandLineTestCase):
         self.assertEqual(RULE_NONE, table.hrules)
 
     def test_format_html(self) -> None:
-        format_html_args = ["--format=html"]
+        format_html_args = ["--format=html", "--with-authors"]
         args = self.parser.parse_args(format_html_args)
         output_string = create_output_string(args)
 
         self.assertIn("<table>", output_string)
+        self.assertIn("Filipe La&#237;ns", output_string)  # author of "build"
 
     def test_format_json(self) -> None:
         format_json_args = ["--format=json", "--with-authors"]


### PR DESCRIPTION
This should fix broken author names etc. when viewing the output in browser.

My current workflow is to save the `--format html` output from pip-licenses straight to a file. To have non-broken author names when viewing that in a browser, need to either wrap the output in a full html document that sets an encoding or, as I'm doing now, pipe through `python -c "import sys; s = sys.stdin.read(); print(s.encode('ascii', errors='xmlcharrefreplace').decode('ascii'))"` which is basically the change in this PR.

It feels better to add this here, rather than upstream in prettytable, since that package works fine outputting utf-8 in the context of including tables in larger documents.