### PR TITLE
Case-insensitive license name matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,7 +446,8 @@ If the input strings are filtered (see `--filter-strings`), you can specify the 
 
 #### Option: fail\-on
 
-Fail (exit with code 1) on the first occurrence of the licenses of the semicolon-separated list
+Fail (exit with code 1) on the first occurrence of the licenses of the semicolon-separated list. The license name
+matching is case-insensitive.
 
 If `--from=all`, the option will apply to the metadata license field.
 
@@ -456,18 +457,23 @@ If `--from=all`, the option will apply to the metadata license field.
 **Note:** Packages with multiple licenses will fail if at least one license is included in the fail-on list. For example:
 ```
 # keyring library has 2 licenses
-$ pip-licenses | grep keyring
- keyring             21.4.0     Python Software Foundation License, MIT License
+$ pip-licenses --package keyring
+ Name     Version  License                                         
+ keyring  23.0.1   MIT License; Python Software Foundation License
 
 # If just "Python Software Foundation License" is specified, it will fail.
-$ pip-licenses --fail-on="Python Software Foundation License;"
+$ pip-licenses --package keyring --fail-on="Python Software Foundation License;"
 $ echo $?
 1
+
+# Matching is case-insensitive. Following check will fail:
+$ pip-licenses --fail-on="mit license"
 ```
 
 #### Option: allow\-only
 
-Fail (exit with code 1) if none of the package licenses are in the semicolon-separated list
+Fail (exit with code 1) if none of the package licenses are in the semicolon-separated list. The license name
+matching is case-insensitive.
 
 If `--from=all`, the option will apply to the metadata license field.
 
@@ -481,8 +487,9 @@ $ pip-licenses --package keyring
  Name     Version  License                                         
  keyring  23.0.1   MIT License; Python Software Foundation License
 
-# One or both licenses must be specified (order does not matter). Following checks will pass:
+# One or both licenses must be specified (order and case does not matter). Following checks will pass:
 $ pip-licenses --package keyring --allow-only="MIT License"
+$ pip-licenses --package keyring --allow-only="mit License"
 $ pip-licenses --package keyring --allow-only="BSD License;MIT License"
 $ pip-licenses --package keyring --allow-only="Python Software Foundation License"
 $ pip-licenses --package keyring --allow-only="Python Software Foundation License;MIT License"

--- a/piplicenses.py
+++ b/piplicenses.py
@@ -190,24 +190,6 @@ def get_packages(
 
         return pkg_info
 
-    def case_insensitive_set_intersect(set_a, set_b):
-        """Same as set.intersection() but case-insensitive"""
-        common_items = set()
-        set_b_lower = {item.lower() for item in set_b}
-        for elem in set_a:
-            if elem.lower() in set_b_lower:
-                common_items.add(elem)
-        return common_items
-
-    def case_insensitive_set_diff(set_a, set_b):
-        """Same as set.difference() but case-insensitive"""
-        uncommon_items = set()
-        set_b_lower = {item.lower() for item in set_b}
-        for elem in set_a:
-            if not elem.lower() in set_b_lower:
-                uncommon_items.add(elem)
-        return uncommon_items
-
     pkgs = importlib_metadata.distributions()
     ignore_pkgs_as_lower = [pkg.lower() for pkg in args.ignore_packages]
     pkgs_as_lower = [pkg.lower() for pkg in args.packages]
@@ -322,6 +304,26 @@ def create_summary_table(args: CustomNamespace) -> PrettyTable:
     for license, count in counts.items():
         table.add_row([count, license])
     return table
+
+
+def case_insensitive_set_intersect(set_a, set_b):
+    """Same as set.intersection() but case-insensitive"""
+    common_items = set()
+    set_b_lower = {item.lower() for item in set_b}
+    for elem in set_a:
+        if elem.lower() in set_b_lower:
+            common_items.add(elem)
+    return common_items
+
+
+def case_insensitive_set_diff(set_a, set_b):
+    """Same as set.difference() but case-insensitive"""
+    uncommon_items = set()
+    set_b_lower = {item.lower() for item in set_b}
+    for elem in set_a:
+        if not elem.lower() in set_b_lower:
+            uncommon_items.add(elem)
+    return uncommon_items
 
 
 class JsonPrettyTable(PrettyTable):

--- a/piplicenses.py
+++ b/piplicenses.py
@@ -190,6 +190,24 @@ def get_packages(
 
         return pkg_info
 
+    def case_insensitive_set_intersect(set_a, set_b):
+        """Same as set.intersection() but case-insensitive"""
+        common_items = set()
+        set_b_lower = {item.lower() for item in set_b}
+        for elem in set_a:
+            if elem.lower() in set_b_lower:
+                common_items.add(elem)
+        return common_items
+
+    def case_insensitive_set_diff(set_a, set_b):
+        """Same as set.difference() but case-insensitive"""
+        uncommon_items = set()
+        set_b_lower = {item.lower() for item in set_b}
+        for elem in set_a:
+            if not elem.lower() in set_b_lower:
+                uncommon_items.add(elem)
+        return uncommon_items
+
     pkgs = importlib_metadata.distributions()
     ignore_pkgs_as_lower = [pkg.lower() for pkg in args.ignore_packages]
     pkgs_as_lower = [pkg.lower() for pkg in args.packages]
@@ -223,7 +241,9 @@ def get_packages(
         )
 
         if fail_on_licenses:
-            failed_licenses = license_names.intersection(fail_on_licenses)
+            failed_licenses = case_insensitive_set_intersect(
+                license_names, fail_on_licenses
+            )
             if failed_licenses:
                 sys.stderr.write(
                     "fail-on license {} was found for package "
@@ -236,7 +256,9 @@ def get_packages(
                 sys.exit(1)
 
         if allow_only_licenses:
-            uncommon_licenses = license_names.difference(allow_only_licenses)
+            uncommon_licenses = case_insensitive_set_diff(
+                license_names, allow_only_licenses
+            )
             if len(uncommon_licenses) == len(license_names):
                 sys.stderr.write(
                     "license {} not in allow-only licenses was found"

--- a/test_piplicenses.py
+++ b/test_piplicenses.py
@@ -29,6 +29,8 @@ from piplicenses import (
     CompatibleArgumentParser,
     FromArg,
     __pkgname__,
+    case_insensitive_set_diff,
+    case_insensitive_set_intersect,
     create_licenses_table,
     create_output_string,
     create_parser,
@@ -668,6 +670,34 @@ class TestGetLicenses(CommandLineTestCase):
         piplicenses.importlib_metadata.distributions = (
             importlib_metadata_distributions_orig
         )
+
+    def test_case_insensitive_set_diff(self) -> None:
+        set_a = {"MIT License"}
+        set_b = {"Mit License", "BSD License"}
+        set_c = {"mit license"}
+        a_diff_b = case_insensitive_set_diff(set_a, set_b)
+        a_diff_c = case_insensitive_set_diff(set_a, set_c)
+        b_diff_c = case_insensitive_set_diff(set_b, set_c)
+        a_diff_empty = case_insensitive_set_diff(set_a, set())
+
+        self.assertTrue(len(a_diff_b) == 0)
+        self.assertTrue(len(a_diff_c) == 0)
+        self.assertIn("BSD License", b_diff_c)
+        self.assertIn("MIT License", a_diff_empty)
+
+    def test_case_insensitive_set_intersect(self) -> None:
+        set_a = {"Revised BSD"}
+        set_b = {"Apache License", "revised BSD"}
+        set_c = {"revised bsd"}
+        a_intersect_b = case_insensitive_set_intersect(set_a, set_b)
+        a_intersect_c = case_insensitive_set_intersect(set_a, set_c)
+        b_intersect_c = case_insensitive_set_intersect(set_b, set_c)
+        a_intersect_empty = case_insensitive_set_intersect(set_a, set())
+
+        self.assertTrue(set_a == a_intersect_b)
+        self.assertTrue(set_a == a_intersect_c)
+        self.assertTrue({"revised BSD"} == b_intersect_c)
+        self.assertTrue(len(a_intersect_empty) == 0)
 
 
 class MockStdStream(object):

--- a/test_piplicenses.py
+++ b/test_piplicenses.py
@@ -220,14 +220,14 @@ class TestGetLicenses(CommandLineTestCase):
         for row in table.rows:
             license_classifier.append(row[index_license_classifier])
 
-        for license in ("BSD", "MIT", "Apache 2.0"):
-            self.assertIn(license, license_meta)
-        for license in (
+        for license_name in ("BSD", "MIT", "Apache 2.0"):
+            self.assertIn(license_name, license_meta)
+        for license_name in (
             "BSD License",
             "MIT License",
             "Apache Software License",
         ):
-            self.assertIn(license, license_classifier)
+            self.assertIn(license_name, license_classifier)
 
     def test_find_license_from_classifier(self) -> None:
         classifiers = ["License :: OSI Approved :: MIT License"]

--- a/test_piplicenses.py
+++ b/test_piplicenses.py
@@ -726,7 +726,7 @@ def test_output_file_none(monkeypatch) -> None:
 
 def test_allow_only(monkeypatch) -> None:
     licenses = (
-        "BSD License",
+        "Bsd License",
         "Apache Software License",
         "Mozilla Public License 2.0 (MPL 2.0)",
         "Python Software Foundation License",
@@ -751,7 +751,7 @@ def test_allow_only(monkeypatch) -> None:
 
 
 def test_fail_on(monkeypatch) -> None:
-    licenses = ("MIT License",)
+    licenses = ("MIT license",)
     allow_only_args = ["--fail-on={}".format(";".join(licenses))]
     mocked_stdout = MockStdStream()
     mocked_stderr = MockStdStream()


### PR DESCRIPTION
* Matching license names with `allow-only` and `fail-on` options is no longer case-sensitive #145 
* Updated Readme and tests