### PR TITLE
feat: Use `author-email` metadata as fallback if `author` is None

### DIFF
--- a/piplicenses.py
+++ b/piplicenses.py
@@ -93,7 +93,7 @@ SUMMARY_OUTPUT_FIELDS = (
     "License",
 )
 
-METADATA_KEYS: dict[str, list[str]] = {
+METADATA_KEYS = {
     "home-page": ["home-page"],
     "author": ["author", "author-email"],
     "license": ["license"],

--- a/piplicenses.py
+++ b/piplicenses.py
@@ -93,13 +93,12 @@ SUMMARY_OUTPUT_FIELDS = (
     "License",
 )
 
-
-METADATA_KEYS = (
-    "home-page",
-    "author",
-    "license",
-    "summary",
-)
+METADATA_KEYS: dict[str, tuple[str, ...]] = {
+    "home-page": "home-page",
+    "author": ["author", "author-email"],
+    "license": "license",
+    "summary": "summary",
+}
 
 # Mapping of FIELD_NAMES to METADATA_KEYS where they differ by more than case
 FIELDS_TO_METADATA_KEYS = {
@@ -167,8 +166,13 @@ def get_packages(
             "noticetext": notice_text,
         }
         metadata = pkg.metadata
-        for key in METADATA_KEYS:
-            pkg_info[key] = metadata.get(key, LICENSE_UNKNOWN)  # type: ignore[attr-defined] # noqa: E501
+        for field_name, field_selectors in METADATA_KEYS.items():
+            value = None
+            for selector in field_selectors:
+                value = metadata.get(selector, None)  # type: ignore[attr-defined] # noqa: E501
+                if value:
+                    break
+            pkg_info[field_name] = value or LICENSE_UNKNOWN
 
         classifiers: list[str] = metadata.get_all("classifier", [])
         pkg_info["license_classifier"] = find_license_from_classifier(

--- a/piplicenses.py
+++ b/piplicenses.py
@@ -93,11 +93,11 @@ SUMMARY_OUTPUT_FIELDS = (
     "License",
 )
 
-METADATA_KEYS: dict[str, tuple[str, ...]] = {
-    "home-page": "home-page",
+METADATA_KEYS: dict[str, list[str]] = {
+    "home-page": ["home-page"],
     "author": ["author", "author-email"],
-    "license": "license",
-    "summary": "summary",
+    "license": ["license"],
+    "summary": ["summary"],
 }
 
 # Mapping of FIELD_NAMES to METADATA_KEYS where they differ by more than case


### PR DESCRIPTION
I noticed that some packages (e.g. [termcolor](https://github.com/termcolor/termcolor)) do not declare an author (metadata field `author`) but the email address of the author (metadata field `author-email`). For this reason I think it is appropriate to use this value as a fallback value.

Current output:
```
Name       Version  License      Author                                      
termcolor  2.2.0    MIT License  UNKNOWN
```

New output:
```
Name       Version  License      Author                                      
termcolor  2.2.0    MIT License  Konstantin Lepa <konstantin.lepa@gmail.com>
```

Other examples for packages with defined `author-email` but no `author`
* https://pypi.org/project/tomli/
* https://pypi.org/project/tabulate/
* https://pypi.org/project/uvicorn/