### PR TITLE
feat: Use `Project-URL` metadata as fallback if `home-page` is None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Implement new option `--python`
 * Allow version spec in `--ignore-packages` parameters
 * When the `Author` field is `UNKNOWN`, the output is automatically completed from `Author-email`
+* When the `home-page` field is `UNKNOWN`, the output is automatically completed from `Project-URL`
 
 ### 4.1.0
 


### PR DESCRIPTION
Hello again!

This PR basically cleans up my last fallback solution with a slightly more cleaner way to get the values from the metadata by using (type annotated) lambda functions and uses the **first** `Project-URL` value of the metadata.

Current output:
```
Name       Version  License      Author                                       URL     
termcolor  2.2.0    MIT License  Konstantin Lepa <konstantin.lepa@gmail.com>  UNKNOWN
```

New output:
```
Name            Version  License      Author                                      URL  
termcolor       2.2.0    MIT License  Konstantin Lepa <konstantin.lepa@gmail.com> https://github.com/termcolor/termcolor
```



