### PR TITLE
feat: adding `--no-version` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Dump the software license list of Python packages installed with pip.
         * [Option: with\-maintainers](#option-with-maintainers)
         * [Option: with\-urls](#option-with-urls)
         * [Option: with\-description](#option-with-description)
+        * [Option: no\-version](#option-no-version)
         * [Option: with\-license\-file](#option-with-license-file)
         * [Option: filter\-strings](#option-filter-strings)
         * [Option: filter\-code\-page](#option-filter-code-page)
@@ -456,6 +457,17 @@ When executed with the `--with-description` option, output with short descriptio
  Name    Version  License  Description
  Django  2.0.2    BSD      A high-level Python Web framework that encourages rapid development and clean, pragmatic design.
  pytz    2017.3   MIT      World timezone definitions, modern and historical
+```
+
+#### Option: no-version
+
+When executed with the `--no-version` option, output without the version number.
+
+```bash
+(venv) $ pip-licenses --no-version
+ Name    License
+ Django  BSD
+ pytz    MIT
 ```
 
 #### Option: with-license-file

--- a/piplicenses.py
+++ b/piplicenses.py
@@ -594,6 +594,9 @@ def get_output_fields(args: CustomNamespace) -> list[str]:
     if args.with_description:
         output_fields.append("Description")
 
+    if args.no_version:
+        output_fields.remove("Version")
+
     if args.with_license_file:
         if not args.no_license_path:
             output_fields.append("LicenseFile")
@@ -965,6 +968,13 @@ def create_parser() -> CompatibleArgumentParser:
         action="store_true",
         default=False,
         help="dump with short package description",
+    )
+    format_options.add_argument(
+        "-nv",
+        "--no-version",
+        action="store_true",
+        default=False,
+        help="dump without package version",
     )
     format_options.add_argument(
         "-l",

--- a/test_piplicenses.py
+++ b/test_piplicenses.py
@@ -344,6 +344,17 @@ class TestGetLicenses(CommandLineTestCase):
         output_string = create_output_string(args)
         self.assertIn("Description", output_string)
 
+    def test_without_version(self) -> None:
+        without_version_args = ["--no-version"]
+        args = self.parser.parse_args(without_version_args)
+
+        output_fields = get_output_fields(args)
+        self.assertNotEqual(output_fields, list(DEFAULT_OUTPUT_FIELDS))
+        self.assertNotIn("Version", output_fields)
+
+        output_string = create_output_string(args)
+        self.assertNotIn("Version", output_string)
+
     def test_with_license_file(self) -> None:
         with_license_file_args = ["--with-license-file"]
         args = self.parser.parse_args(with_license_file_args)


### PR DESCRIPTION
to avoid exporting the version number of packages.

I.E. for security reasons you want to export licenses without the specific version number.