### PR TITLE
package URL extraction improvements 

### DIFF
--- a/piplicenses.py
+++ b/piplicenses.py
@@ -122,7 +122,13 @@ def extract_homepage(metadata: Message) -> Optional[str]:
         key, value = entry.split(",", 1)
         candidates[key.strip().lower()] = value.strip()
 
-    for priority_key in ["homepage", "source", "changelog", "bug tracker"]:
+    for priority_key in [
+        "homepage",
+        "source",
+        "repository",
+        "changelog",
+        "bug tracker",
+    ]:
         if priority_key in candidates:
             return candidates[priority_key]
 

--- a/piplicenses.py
+++ b/piplicenses.py
@@ -120,9 +120,9 @@ def extract_homepage(metadata: Message) -> Optional[str]:
 
     for entry in metadata.get_all("Project-URL", []):
         key, value = entry.split(",", 1)
-        candidates[key.strip()] = value.strip()
+        candidates[key.strip().lower()] = value.strip()
 
-    for priority_key in ["Homepage", "Source", "Changelog", "Bug Tracker"]:
+    for priority_key in ["homepage", "source", "changelog", "bug tracker"]:
         if priority_key in candidates:
             return candidates[priority_key]
 

--- a/test_piplicenses.py
+++ b/test_piplicenses.py
@@ -1004,3 +1004,18 @@ def test_extract_homepage_empty() -> None:
 
     metadata.get.assert_called_once_with("home-page", None)
     metadata.get_all.assert_called_once_with("Project-URL", [])
+
+
+def test_extract_homepage_project_uprl_fallback_capitalisation() -> None:
+    metadata = MagicMock()
+    metadata.get.return_value = None
+
+    # `homepage` is still prioritized higher than `Source` (capitalisation)
+    metadata.get_all.return_value = [
+        "Source, source",
+        "homepage, homepage",
+    ]
+
+    assert "homepage" == extract_homepage(metadata=metadata)  # type: ignore
+
+    metadata.get_all.assert_called_once_with("Project-URL", [])


### PR DESCRIPTION
This PR has 2 parts:

1. Switch to case-insensitive matching of fallback amongst the entries `Project-URL`. Came across many projects that do use lowercase for their entries, and previously they were listed with URL being `UNKOWN`.
2. Add `repository` as another fallback. This I see popping up quite a bit among projects, instead of `source`.

Happy to hear feedback on either of these. 1. is a blocker for us on some projects, 2. is a potential nice-to-have but optional (added in a separate commit).