### PR TITLE
Add PYTHONIOENCODING hint to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,7 +602,7 @@ index bfc4edc..175e968 100644
 
 ## About UnicodeEncodeError
 
-If a `UnicodeEncodeError` occurs, check your environment variables `LANG` and `LC_TYPE`.
+If a `UnicodeEncodeError` occurs, check your environment variables `LANG` and `LC_TYPE`. Additionally, you can set `PYTHONIOENCODING` to override the encoding used for `stdout`.
 
 Often occurs in isolated environments such as Docker and tox.
 


### PR DESCRIPTION
Using `cmd` via VSCode on Windows 11, I was unable to get past the `UnicodeEncodeError` either unsetting or setting these environment variables. Setting `PYTHONIOENCODING="utf-8"` did let me get things working.

Thank you for this package and your work maintaining it.