### PR TITLE
Update version of Codecov GitHub Action to v4

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -39,9 +39,10 @@ jobs:
           mypy --install-types --non-interactive .
       - name: Upload code coverage to Codecov
         if: ${{ matrix.python-version==3.8 }}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
-          file: ./coverage.xml
+          files: ./coverage.xml
           name: codecov-umbrella
           fail_ci_if_error: true
+          verbose: true

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -36,7 +36,7 @@ docutils==0.19
     #   readme-renderer
 exceptiongroup==1.2.0
     # via pytest
-idna==3.4
+idna==3.7
     # via requests
 importlib-metadata==5.1.0
     # via

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -107,7 +107,7 @@ pytest-runner==6.0.0
     # via -r dev-requirements.in
 readme-renderer==37.3
     # via twine
-requests==2.31.0
+requests==2.32.0
     # via
     #   requests-toolbelt
     #   twine


### PR DESCRIPTION
I'm trying to use v4 because of an error uploading coverage.

OK, PRs made by dependabot was cherry picked.

Close #190 
Close #191 