### PR TITLE
Support parsing input parametres from `pyproject.toml` config

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Dump the software license list of Python packages installed with pip.
         * [Option: fail\-on](#option-fail-on)
         * [Option: allow\-only](#option-allow-only)
         * [Option: partial\-match](#option-partial-match)
+    * [pyproject.toml support](#pyproject-toml-support)
     * [More Information](#more-information)
 * [Dockerfile](#dockerfile)
 * [About UnicodeEncodeError](#about-unicodeencodeerror)
@@ -589,7 +590,7 @@ $ echo $?
 0
 ```
 
-#### pyproject.toml support
+### pyproject.toml support
 
 All command-line options for `pip-licenses` can be configured using the `pyproject.toml` file under the `[tool.pip-licenses]` section. 
 The `pyproject.toml` file is searched in the directory where the `pip-licenses` script is executed.

--- a/README.md
+++ b/README.md
@@ -589,6 +589,25 @@ $ echo $?
 0
 ```
 
+#### pyproject.toml support
+
+All command-line options for `pip-licenses` can be configured using the `pyproject.toml` file under the `[tool.pip-licenses]` section. 
+The `pyproject.toml` file is searched in the directory where the `pip-licenses` script is executed.
+Command-line options specified during execution will override the corresponding options in `pyproject.toml`.
+
+Example `pyproject.toml` configuration:
+
+```toml
+[tool.pip-licences]
+from = "classifier"
+ignore-packages = [
+  "scipy"
+]
+fail-on = "MIT;"
+```
+
+If you run `pip-licenses` without any command-line options, all options will be taken from the `pyproject.toml` file. 
+For instance, if you run `pip-licenses --from=mixed`, the `from` option will be overridden to `mixed`, while all other options will be sourced from `pyproject.toml`.
 
 ### More Information
 
@@ -663,6 +682,8 @@ See useful reports:
 
 * [prettytable](https://pypi.org/project/prettytable/) by Luke Maurits and maintainer of fork version Jazzband team under the BSD-3-Clause License
     * **Note:** This package implicitly requires [wcwidth](https://pypi.org/project/wcwidth/).
+
+* [tomli](https://pypi.org/project/tomli/) by Taneli Hukkinen under the MIT License
 
 `pip-licenses` has been implemented in the policy to minimize the dependence on external package.
 

--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -12,3 +12,4 @@ pytest-cov
 pytest-pycodestyle
 pytest-runner
 twine
+tomli-w

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -130,6 +130,8 @@ tomli==2.0.1
     #   mypy
     #   pep517
     #   pytest
+tomli-w==1.0.0
+    # via -r dev-requirements.in
 twine==4.0.2
     # via -r dev-requirements.in
 typing-extensions==4.10.0

--- a/requirements.in
+++ b/requirements.in
@@ -1,1 +1,2 @@
 prettytable
+tomli

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,7 @@
 #
 prettytable==3.9.0
     # via -r requirements.in
+tomli==2.0.1
+    # via -r requirements.in
 wcwidth==0.2.13
     # via prettytable

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ setup_requires =
     pytest-runner
 install_requires =
     prettytable >= 2.3.0
+    tomli >= 2
 tests_require =
     docutils
     mypy
@@ -43,6 +44,7 @@ test =
     pytest-cov
     pytest-pycodestyle
     pytest-runner
+    tomli-w
 
 [bdist_wheel]
 universal = 0


### PR DESCRIPTION
This PR adds possibility to set `pip-licences` input parameters from `pyproject.toml` file. The change made to be minimally invasive to project logic:

- All parameters configurable using CLI are configurable using `pyproject.toml` in the special section for `pip-licences` tool
- Inputs set in CLI have higher priority than `pyproject.toml` and can override them
- All different types of parameters parsing from toml and overriding by cli was tested in a separate test

Main motivation: https://github.com/raimon49/pip-licenses/issues/148 and I really love that in modern python packages you could configure all tools in `pyproject.toml`