### PR TITLE
Release with pyproject.toml

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v4
@@ -38,7 +38,7 @@ jobs:
           mkdir -p .mypy_cache
           mypy --install-types --non-interactive .
       - name: Upload code coverage to Codecov
-        if: ${{ matrix.python-version==3.8 }}
+        if: ${{ matrix.python-version==3.11 }}
         uses: codecov/codecov-action@v4
         with:
           files: ./coverage.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## CHANGELOG
 
+### 5.0.0
+
+* Dropped support Python 3.8
+* Clarified support for Python 3.12
+* Migration pyproject.toml about this package
+* Breaking changes
+    * Implicitly depends on tomli library since version 4.5.0
+
 ### 4.5.1
 
 * Fixes "tomli" to be output only with `--with-system` option

--- a/piplicenses.py
+++ b/piplicenses.py
@@ -57,7 +57,7 @@ if TYPE_CHECKING:
 open = open  # allow monkey patching
 
 __pkgname__ = "pip-licenses"
-__version__ = "4.5.1"
+__version__ = "5.0.0"
 __summary__ = (
     "Dump the software license list of Python packages installed with pip."
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "pip-licenses"
 description = "Dump the software license list of Python packages installed with pip."
 dynamic = ["version", "readme"]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = {text = "MIT"}
 authors = [
     {name = "raimon", email = "raimon49@hotmail.com"}
@@ -18,10 +18,10 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: System :: Systems Administration",
     "Topic :: System :: System Shells",
     "Typing :: Typed"


### PR DESCRIPTION
This release contains #203 

In addition, Python 3.8 will soon be EOL.
https://devguide.python.org/versions/

Therefore, we would also like to set the lower limit of Python versions supported by pip-licenses to 3.9.