### PR TITLE
Update build-system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=40.9.0", "wheel", "setuptools_scm"]
+requires = ["setuptools>=75.1.0", "setuptools_scm"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
Since setuptools `70.1` the `bdist_wheel` command is shipped with setuptools directly. It's no longer necessary to specify `wheel` as a build system requirement.