### PR TITLE
Add support for multi-line allow-only and fail-on arguments

### DIFF
--- a/piplicenses.py
+++ b/piplicenses.py
@@ -284,11 +284,11 @@ def get_packages(
 
     fail_on_licenses = set()
     if args.fail_on:
-        fail_on_licenses = set(map(str.strip, args.fail_on.split(";")))
+        fail_on_licenses = {license.strip() for license in args.fail_on.split(";") if license.strip()}
 
     allow_only_licenses = set()
     if args.allow_only:
-        allow_only_licenses = set(map(str.strip, args.allow_only.split(";")))
+        allow_only_licenses = {license.strip() for license in args.allow_only.split(";") if license.strip()}
 
     for pkg in pkgs:
         pkg_name = normalize_pkg_name(pkg.metadata["name"])


### PR DESCRIPTION
When setting the `allow-only` and `fail-on` arguments, the list can get very long very fast, especially when switching `partial` to `false`. There is a need to make sure multi-line arguments work properly.

Currently when passing multi-line allow-only and fail-on arguments in `pyproject.toml`, the `fail_on_licenses` and `allow_only_licenses` sets were found to contain the empty string `''`.  

e.g. 
```
allow-only="""
MIT;Apache;
"""
```
sets allow_only_licenses to:
```
{'', 'Apache', 'MIT'}
```

The code checks for the same and removes it from the sets, such that there is no empty string:
```
{'Apache', 'MIT'}
```