### PR TITLE
feat: Use `license-expression` as fallback for license (PEP-639)

### DIFF
--- a/piplicenses.py
+++ b/piplicenses.py
@@ -161,7 +161,10 @@ METADATA_KEYS: Dict[str, List[Callable[[Message], Optional[str]]]] = {
         lambda metadata: metadata.get("maintainer"),
         lambda metadata: metadata.get("maintainer-email"),
     ],
-    "license": [lambda metadata: metadata.get("license")],
+    "license": [
+        lambda metadata: metadata.get("license"),
+        lambda metadata: metadata.get("license-expression"),
+    ],
     "summary": [lambda metadata: metadata.get("summary")],
 }
 


### PR DESCRIPTION
[PEP-639](https://peps.python.org/pep-0639/) allows declaring the license in the `License-Expression` metadata field. Using this as fallback fixes resolving the licenses of some packages, e.g. `termcolor==3.0.1`, `prettytable==3.16.0` and `typing_extensions==4.13.1`

**Verifying the change**
```bash
pip-licenses -p prettytable typing-extensions termcolor -a -s -u -d -f json
```

Before
```json
[
  {
    "Author": "Luke Maurits <luke@maurits.id.au>",
    "Description": "A simple Python library for easily displaying tabular data in a visually appealing ASCII table format",
    "License": "UNKNOWN",
    "Name": "prettytable",
    "URL": "https://github.com/prettytable/prettytable",
    "Version": "3.16.0"
  },
  {
    "Author": "Konstantin Lepa <konstantin.lepa@gmail.com>",
    "Description": "ANSI color formatting for output in terminal",
    "License": "UNKNOWN",
    "Name": "termcolor",
    "URL": "https://github.com/termcolor/termcolor",
    "Version": "3.0.1"
  },
  {
    "Author": "\"Guido van Rossum, Jukka Lehtosalo, \u0141ukasz Langa, Michael Lee\" <levkivskyi@gmail.com>",
    "Description": "Backported and Experimental Type Hints for Python 3.8+",
    "License": "UNKNOWN",
    "Name": "typing_extensions",
    "URL": "https://github.com/python/typing_extensions",
    "Version": "4.13.1"
  }
]
```

**After**
```json
[
  {
    "Author": "Luke Maurits <luke@maurits.id.au>",
    "Description": "A simple Python library for easily displaying tabular data in a visually appealing ASCII table format",
    "License": "BSD-3-Clause",
    "Name": "prettytable",
    "URL": "https://github.com/prettytable/prettytable",
    "Version": "3.16.0"
  },
  {
    "Author": "Konstantin Lepa <konstantin.lepa@gmail.com>",
    "Description": "ANSI color formatting for output in terminal",
    "License": "MIT",
    "Name": "termcolor",
    "URL": "https://github.com/termcolor/termcolor",
    "Version": "3.0.1"
  },
  {
    "Author": "\"Guido van Rossum, Jukka Lehtosalo, \u0141ukasz Langa, Michael Lee\" <levkivskyi@gmail.com>",
    "Description": "Backported and Experimental Type Hints for Python 3.8+",
    "License": "PSF-2.0",
    "Name": "typing_extensions",
    "URL": "https://github.com/python/typing_extensions",
    "Version": "4.13.1"
  }
]
```

This resolves #225
This relates to #89
