### PR TITLE
Fix: Correct typo in TOML configuration example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -611,7 +611,7 @@ Command-line options specified during execution will override the corresponding 
 Example `pyproject.toml` configuration:
 
 ```toml
-[tool.pip-licences]
+[tool.pip-licenses]
 from = "classifier"
 ignore-packages = [
   "scipy"


### PR DESCRIPTION
#209 