### PR TITLE
Fix typo in pyproject.toml example

### DIFF
--- a/README.md
+++ b/README.md
@@ -611,7 +611,7 @@ Command-line options specified during execution will override the corresponding 
 Example `pyproject.toml` configuration:
 
 ```toml
-[tool.pip-licences]
+[tool.pip-licenses]
 from = "classifier"
 ignore-packages = [
   "scipy"


### PR DESCRIPTION
This fixes a typo in the pyproject.toml configuration example in the README.

The example had `[tool.pip-licences]` but the correct section name is `[tool.pip-licenses]` (licenses not licences). This typo prevented the example from working as documented.

Fixes #209