### PR TITLE
Fix typo found by codespell

### DIFF
--- a/piplicenses.py
+++ b/piplicenses.py
@@ -147,7 +147,7 @@ def normalize_pkg_name(pkg_name: str) -> str:
                   or specified in the CLI
 
     Returns:
-        normalized packege name
+        normalized package name
     """
     return PATTERN_DELIMITER.sub("-", pkg_name).lower().strip()
 


### PR DESCRIPTION
**edit**: _Corrects the typographical mistake of "packege" to "package"._