### PR TITLE
PEP 639 compliance

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,3 @@
-include LICENSE
 include README.md
 include CHANGELOG.md
 include py.typed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=75.1.0", "setuptools_scm"]
+requires = ["setuptools>=77.0.3", "setuptools_scm"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -7,7 +7,8 @@ name = "pip-licenses"
 description = "Dump the software license list of Python packages installed with pip."
 dynamic = ["version", "readme"]
 requires-python = ">=3.9"
-license = {text = "MIT"}
+license = "MIT"
+license-files = ["LICENSE"]
 authors = [
     {name = "raimon", email = "raimon49@hotmail.com"}
 ]
@@ -15,7 +16,6 @@ keywords = ["pip", "pypi", "package", "license", "check"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
# **EDIT**: PR Summary

## Purpose
bring pyproject/packaging metadata into alignment with PEP 639 and related packaging guidance.
Net effect in this PR: small metadata edits (3 additions, 4 deletions) touching pyproject.toml and MANIFEST.in (see PR for exact diffs).

## What changed

pyproject.toml: updated license-related configuration to use an SPDX-style license expression (string) and added/adjusted license-files configuration.
MANIFEST.in: removed explicit inclusion of LICENSE (the PR author removed LICENSE from MANIFEST.in).
Why (rationale)

PEP 639 modernizes packaging license metadata: build back-ends should accept an SPDX expression in the project.license value and map it into a License-Expression core metadata field.
packaging guides recommend declaring license files in pyproject.toml via license-files so they are included with source distributions.

### References (selected)

* [PEP 639 — Modernizing metadata for license information](https://peps.python.org/pep-0639/)
  * ["Add string value to license key" / mapping to License-Expression](https://peps.python.org/pep-0639/#add-string-value-to-license-key)
  * ["Deprecate license field" section](https://peps.python.org/pep-0639/#deprecate-license-field)
  * [Project source metadata overview](https://peps.python.org/pep-0639/#project-source-metadata)
* **Python Packaging User Guide (relevant sections)**
  * [Writing pyproject.toml — license and license-files](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files)
  * [Core metadata — license-expression](https://packaging.python.org/en/latest/specifications/core-metadata/#license-expression)
  * [pyproject.toml specification — license](https://packaging.python.org/en/latest/specifications/pyproject-toml/#license)