### PR TITLE
Use Well-known labels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dev = [
 
 [project.urls]
 homepage = "https://github.com/raimon49/pip-licenses"
-Releases = "https://github.com/raimon49/pip-licenses/releases"
+releasenotes = "https://github.com/raimon49/pip-licenses/releases"
 issues = "https://github.com/raimon49/pip-licenses/issues"
 
 [project.scripts]


### PR DESCRIPTION
**EDIT**:

## Summary

Alignes project URL metadata with the [well-known labels](https://packaging.python.org/en/latest/specifications/well-known-project-urls/#well-known-labels)

### Namely

* `homepage`
* `issues`
* `releasenotes`

### References

* See [well-known project URLs](https://packaging.python.org/en/latest/specifications/well-known-project-urls/#well-known-labels)
* See also [Historical PEP-753](https://peps.python.org/pep-0753/)

---
<details><summary>Original Description</summary>

https://packaging.python.org/en/latest/specifications/well-known-project-urls/#well-known-labels

Either use the well-known labels:
* homepage
* issues

or the human-readable equivalent:
* Homepage
* Issue Tracker

For now, I haven't changed:
* Releases

to:
* Release Notes

</details>