### PR TITLE
Adapt `MANIFEST.in` to `setuptools-scm`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
-include README.md
-include CHANGELOG.md
-include py.typed
-include test_piplicenses.py
-include tests/fixtures/*.txt
+prune .github
+prune docker
+exclude .gitignore
+exclude CONTRIBUTING.md
+exclude Dockerfile


### PR DESCRIPTION
Because `setuptools-scm` will include all files under Git control, we need to exclude files that we want in the sdist, instead of including files.

Fixes #266.

```console
$ python -m build -s
* Creating virtualenv isolated environment...
* Installing packages in isolated environment... (setuptools>=75.1.0, setuptools_scm)
* Getting dependencies for sdist...
[...]
reading manifest template 'MANIFEST.in'
adding license file 'LICENSE'
writing manifest file 'pip_licenses.egg-info/SOURCES.txt'
running check
creating pip_licenses-5.5.0
creating pip_licenses-5.5.0/pip_licenses.egg-info
creating pip_licenses-5.5.0/tests/fixtures
copying files to pip_licenses-5.5.0...
copying CHANGELOG.md -> pip_licenses-5.5.0
copying LICENSE -> pip_licenses-5.5.0
copying MANIFEST.in -> pip_licenses-5.5.0
copying Makefile -> pip_licenses-5.5.0
copying README.md -> pip_licenses-5.5.0
copying dev-requirements.txt -> pip_licenses-5.5.0
copying piplicenses.py -> pip_licenses-5.5.0
copying py.typed -> pip_licenses-5.5.0
copying pyproject.toml -> pip_licenses-5.5.0
copying requirements.txt -> pip_licenses-5.5.0
copying test_piplicenses.py -> pip_licenses-5.5.0
copying pip_licenses.egg-info/PKG-INFO -> pip_licenses-5.5.0/pip_licenses.egg-info
copying pip_licenses.egg-info/SOURCES.txt -> pip_licenses-5.5.0/pip_licenses.egg-info
copying pip_licenses.egg-info/dependency_links.txt -> pip_licenses-5.5.0/pip_licenses.egg-info
copying pip_licenses.egg-info/entry_points.txt -> pip_licenses-5.5.0/pip_licenses.egg-info
copying pip_licenses.egg-info/requires.txt -> pip_licenses-5.5.0/pip_licenses.egg-info
copying pip_licenses.egg-info/top_level.txt -> pip_licenses-5.5.0/pip_licenses.egg-info
copying tests/fixtures/unicode_characters.txt -> pip_licenses-5.5.0/tests/fixtures
copying pip_licenses.egg-info/SOURCES.txt -> pip_licenses-5.5.0/pip_licenses.egg-info
Writing pip_licenses-5.5.0/setup.cfg
Creating tar archive
[...]
$ 
```