### PR TITLE
Lint using pre-commit - locally and in CI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -21,17 +21,8 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.14'
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          if [ -f dev-requirements.txt ]; then pip install -r dev-requirements.txt; fi
-      - name: Lint and format with ruff
-        run: |
-          ruff check --diff
-          ruff format --diff
-      - name: Validate static typing with mypy
-        run: | # the target Python version should be the earliest supported version
-          mypy --install-types --non-interactive --python-version 3.9 .
+      - name: Run pre-commit
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
 
   build:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+---
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.1
+    hooks:
+      - id: ruff-check
+        args: [ --fix ]
+      - id: ruff-format
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.19.1
+    hooks:
+      - id: mypy
+        additional_dependencies:
+          - types-docutils

--- a/Makefile
+++ b/Makefile
@@ -166,9 +166,7 @@ build: clean
 	$(VENV_NAME)/bin/python -m build
 
 lint:
-	$(VENV_NAME)/bin/python -m ruff --config pyproject.toml check .
-	$(VENV_NAME)/bin/python -m ruff --config pyproject.toml format .
-	$(VENV_NAME)/bin/python -m mypy --install-types --non-interactive .
+	$(VENV_NAME)/bin/python -m pre-commit run -a
 
 test:
 	$(VENV_NAME)/bin/python -m pytest

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -12,6 +12,8 @@ certifi==2026.1.4
     # via requests
 cffi==2.0.0
     # via cryptography
+cfgv==3.4.0
+    # via pre-commit
 charset-normalizer==3.4.4
     # via requests
 click==8.1.8
@@ -20,14 +22,20 @@ coverage[toml]==7.10.7
     # via pytest-cov
 cryptography==46.0.5
     # via secretstorage
+distlib==0.4.0
+    # via virtualenv
 docutils==0.22.4
     # via
     #   pip-licenses (pyproject.toml)
     #   readme-renderer
 exceptiongroup==1.3.1
     # via pytest
-id==1.5.0
+filelock==3.19.1
+    # via virtualenv
+id==1.6.1
     # via twine
+identify==2.6.15
+    # via pre-commit
 idna==3.11
     # via requests
 importlib-metadata==8.7.1
@@ -49,8 +57,6 @@ jeepney==0.9.0
     #   secretstorage
 keyring==25.7.0
     # via twine
-librt==0.7.8
-    # via mypy
 markdown-it-py==3.0.0
     # via rich
 mdurl==0.1.2
@@ -59,26 +65,26 @@ more-itertools==10.8.0
     # via
     #   jaraco-classes
     #   jaraco-functools
-mypy==1.19.1
-    # via pip-licenses (pyproject.toml)
-mypy-extensions==1.1.0
-    # via mypy
-nh3==0.3.2
+nh3==0.3.3
     # via readme-renderer
+nodeenv==1.10.0
+    # via pre-commit
 packaging==26.0
     # via
     #   build
     #   pytest
     #   twine
     #   wheel
-pathspec==1.0.4
-    # via mypy
-pip-tools==7.5.2
+pip-tools==7.5.3
     # via pip-licenses (pyproject.toml)
+platformdirs==4.4.0
+    # via virtualenv
 pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
+pre-commit==4.3.0
+    # via pip-licenses (pyproject.toml)
 prettytable==3.16.0
     # via pip-licenses (pyproject.toml)
 pycparser==2.23
@@ -100,28 +106,26 @@ pytest-cov==7.0.0
     # via pip-licenses (pyproject.toml)
 pytest-runner==6.0.1
     # via pip-licenses (pyproject.toml)
+pyyaml==6.0.3
+    # via pre-commit
 readme-renderer==44.0
     # via twine
 requests==2.32.5
     # via
-    #   id
     #   requests-toolbelt
     #   twine
 requests-toolbelt==1.0.0
     # via twine
 rfc3986==2.0.0
     # via twine
-rich==14.3.1
+rich==14.3.2
     # via twine
-ruff==0.14.14
-    # via pip-licenses (pyproject.toml)
 secretstorage==3.3.3
     # via keyring
 tomli==2.4.0 ; python_version < "3.11"
     # via
     #   build
     #   coverage
-    #   mypy
     #   pip-licenses (pyproject.toml)
     #   pip-tools
     #   pytest
@@ -133,12 +137,17 @@ typing-extensions==4.15.0
     # via
     #   cryptography
     #   exceptiongroup
-    #   mypy
+    #   virtualenv
 urllib3==2.6.3
     # via
+    #   id
     #   requests
     #   twine
-wcwidth==0.5.2
+virtualenv==20.35.4
+    # via
+    #   pip-licenses (pyproject.toml)
+    #   pre-commit
+wcwidth==0.6.0
     # via prettytable
 wheel==0.46.3
     # via

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,14 +37,16 @@ dependencies = [
 dev = [
     "docutils",
     "wheel",
-    "mypy",
     "pip-tools",
+    "pre-commit",
     "pypandoc",
     "pytest-cov",
     "pytest-runner",
-    "ruff",
     "twine",
-    "tomli-w"
+    "tomli-w",
+    # virtualenv 20.36 is incompatible with Python 3.9:
+    # https://github.com/pypa/virtualenv/issues/3037
+    "virtualenv<20.36.0",
 ]
 
 [project.urls]
@@ -97,7 +99,8 @@ ignore = [
 isort.known-first-party = ["piplicenses"]
 
 [tool.mypy]
-exclude = ["venv"] # and thus venv[subprocess].CalledProcessError
+exclude = ["venv"]   # and thus venv[subprocess].CalledProcessError
+python_version = 3.9 # should be the earliest supported version
 
 [tool.coverage.run]
 include = ["piplicenses.py"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 prettytable==3.16.0
     # via pip-licenses (pyproject.toml)
-tomli==2.3.0 ; python_version < "3.11"
+tomli==2.4.0 ; python_version < "3.11"
     # via pip-licenses (pyproject.toml)
-wcwidth==0.2.14
+wcwidth==0.6.0
     # via prettytable


### PR DESCRIPTION
Run pre-commit as a GitHub Action instead of giving pre-commit.ci access to this repository.

Fixes #288.