### PR TITLE
Fix warning in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "docutils",
+    "docutils>=0.19", # frontend.get_default_settings()
     "wheel",
     "mypy",
     "pip-tools",

--- a/test_piplicenses.py
+++ b/test_piplicenses.py
@@ -133,10 +133,10 @@ class TestGetLicenses(CommandLineTestCase):
     @staticmethod
     def check_rst(text: str) -> None:
         parser = docutils.parsers.rst.Parser()
-        components = (docutils.parsers.rst.Parser,)
-        settings = docutils.frontend.OptionParser(
-            components=components
-        ).get_default_values()
+        component = docutils.parsers.rst.Parser
+        settings = docutils.frontend.get_default_settings(
+            component  # type: ignore[arg-type]  # https://sourceforge.net/p/docutils/patches/216/
+        )
         settings.halt_level = 3
         document = docutils.utils.new_document("<rst-doc>", settings=settings)
         parser.parse(text, document)


### PR DESCRIPTION
```
test_piplicenses.py::TestGetLicenses::test_format_rst_default_filter
  /home/runner/work/pip-licenses/pip-licenses/test_piplicenses.py:137: DeprecationWarning: The frontend.OptionParser class will be replaced by a subclass of argparse.ArgumentParser in Docutils 2.0 or later.
    To get default settings, use frontend.get_default_settings().
    settings = docutils.frontend.OptionParser(

test_piplicenses.py: 72 warnings
  /opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/optparse.py:1000: DeprecationWarning: The frontend.Option class will be removed in Docutils 2.0 or later.
    option = self.option_class(*args, **kwargs)
```