### PR TITLE
Get rid of Python 3.5 left-over

### DIFF
--- a/test_piplicenses.py
+++ b/test_piplicenses.py
@@ -614,10 +614,6 @@ class TestGetLicenses(CommandLineTestCase):
         self.assertEqual("|", table.junction_char)
         self.assertEqual(HRuleStyle.HEADER, table.hrules)
 
-    @unittest.skipIf(
-        sys.version_info < (3, 6, 0),
-        "To unsupport Python 3.5 in the near future",
-    )
     def test_format_rst_without_filter(self) -> None:
         piplicenses.importlib_metadata.distributions = (
             importlib_metadata_distributions_mocked


### PR DESCRIPTION
**EDIT**:

> This is just a test, not the source code itself. Tests run with Python ≥ 3.9. Attempting to protect from that is over-engineering. Besides, f-strings were introduced in Python 3.6, so any attempt to use Python 3.5 would break havoc well before reaching this test.

_Originally posted by @DimitriPapadopoulos in https://github.com/raimon49/pip-licenses/pull/305#discussion_r2810101839_
            