### PR TITLE
Chore: Upgrade samples packages in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,11 @@ $ pip install 'pip-licenses<2.0'
 
 ## Usage
 
-Execute the command with your venv (or virtualenv) environment.
+Simply invoke the command to scan the current environment:
+
+`pip-licenses`
+
+Alternatively execute the command within `virtualenv` (or the legacy `venv`) environment.
 
 ```bash
 # Install packages in your venv environment
@@ -94,8 +98,8 @@ Execute the command with your venv (or virtualenv) environment.
 # Check the licenses with your venv environment
 (venv) $ pip-licenses
  Name    Version  License
- Django  2.0.2    BSD
- pytz    2017.3   MIT
+ Django  6.0.6    BSD-3-Clause
+ pytz    2026.2   MIT License
 ```
 
 ## Command-Line Options
@@ -108,13 +112,13 @@ By default, this tools finds the packages from the environment pip-licenses is l
 
 ```bash
 (venv) $ pip-licenses --with-system | grep pip
- pip                       22.3.1       MIT License
- pip-licenses              4.1.0        MIT License
+ pip           26.1.2   MIT
+ pip-licenses  5.5.5    MIT
 ```
 
 ```bash
 (venv) $ pip-licenses --python=</path/to/other/env>/bin/python --with-system | grep pip
- pip                       23.0.1       MIT License 
+ pip           26.1.2   MIT
 ```
 
 #### Option: from
@@ -123,24 +127,26 @@ By default, this tool finds the license from [Trove Classifiers](https://pypi.or
 
 (See also): [Set license to MIT in setup.py by alisianoi ・ Pull Request #1058 ・ pypa/setuptools](https://github.com/pypa/setuptools/pull/1058), [PEP 314\#License](https://www.python.org/dev/peps/pep-0314/#license)
 
-For example, even if you check with the `pip show` command, the license is displayed as `UNKNOWN`.
+For example, even if you check with the `pip show` command, the license is displayed as `UNKNOWN` or simply empty.
 
 ```bash
-(venv) $ pip show setuptools
-Name: setuptools
-Version: 38.5.0
-Summary: Easily download, build, install, upgrade, and uninstall Python packages
-Home-page: https://github.com/pypa/setuptools
-Author: Python Packaging Authority
-Author-email: distutils-sig@python.org
-License: UNKNOWN
+(venv) $ pip show aniso8601
+Name: aniso8601
+Version: 10.0.1
+Summary: A library for parsing ISO 8601 strings.
+Home-page: https://codeberg.org/nielsenb-jf/aniso8601
+Author: Brandon Nielsen
+Author-email: nielsenb@jetfuse.net
+License:
+Requires:
+Required-by:
 ```
 
 The mixed mode (`--from=mixed`) of this tool works well and looks for licenses.
 
 ```bash
-(venv) $ pip-licenses --from=mixed --with-system | grep setuptools
- setuptools    38.5.0   MIT License
+(venv) $ pip-licenses --from=mixed --with-system | grep aniso8601
+ aniso8601          10.0.1   BSD License
 ```
 
 In mixed mode, it first tries to look for licenses in the Trove Classifiers. When not found in the Trove Classifiers, the license declared in Metadata is displayed.
@@ -176,32 +182,30 @@ When executed with the `--format=markdown` option, you can output list in markdo
 
 ```bash
 (venv) $ pip-licenses --format=markdown
-| Name   | Version | License |
-|--------|---------|---------|
-| Django | 2.0.2   | BSD     |
-| pytz   | 2017.3  | MIT     |
+| Name   | Version | License      |
+|--------|---------|--------------|
+| Django | 6.0.6   | BSD-3-Clause |
+| pytz   | 2026.2  | MIT License  |
 ```
 
 When inserted in a markdown document, it is rendered as follows:
 
-| Name   | Version | License |
-|--------|---------|---------|
-| Django | 2.0.2   | BSD     |
-| pytz   | 2017.3  | MIT     |
-
-##### reST
+| Name   | Version | License      |
+|--------|---------|--------------|
+| Django | 6.0.6   | BSD-3-Clause |
+| pytz   | 2026.2  | MIT License  |
 
 When executed with the `--format=rst` option, you can output list in "[Grid tables](http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#grid-tables)" of reStructuredText format. The `r` `rest` keyword is prepared as alias of `rst`.
 
 ```bash
 (venv) $ pip-licenses --format=rst
-+--------+---------+---------+
-| Name   | Version | License |
-+--------+---------+---------+
-| Django | 2.0.2   | BSD     |
-+--------+---------+---------+
-| pytz   | 2017.3  | MIT     |
-+--------+---------+---------+
++--------+---------+--------------+
+| Name   | Version | License      |
++--------+---------+--------------+
+| Django | 6.0.6   | BSD-3-Clause |
++--------+---------+--------------+
+| pytz   | 2026.2  | MIT License  |
++--------+---------+--------------+
 ```
 
 ##### Confluence
@@ -210,9 +214,9 @@ When executed with the `--format=confluence` option, you can output list in [Con
 
 ```bash
 (venv) $ pip-licenses --format=confluence
-| Name   | Version | License |
-| Django | 2.0.2   | BSD     |
-| pytz   | 2017.3  | MIT     |
+| Name   | Version | License      |
+| Django | 6.0.6   | BSD-3-Clause |
+| pytz   | 2026.2  | MIT License  |
 ```
 
 ##### HTML
@@ -222,21 +226,25 @@ When executed with the `--format=html` option, you can output list in HTML table
 ```bash
 (venv) $ pip-licenses --format=html
 <table>
-    <tr>
-        <th>Name</th>
-        <th>Version</th>
-        <th>License</th>
-    </tr>
-    <tr>
-        <td>Django</td>
-        <td>2.0.2</td>
-        <td>BSD</td>
-    </tr>
-    <tr>
-        <td>pytz</td>
-        <td>2017.3</td>
-        <td>MIT</td>
-    </tr>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Version</th>
+            <th>License</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Django</td>
+            <td>6.0.6</td>
+            <td>BSD-3-Clause</td>
+        </tr>
+        <tr>
+            <td>pytz</td>
+            <td>2026.2</td>
+            <td>MIT License</td>
+        </tr>
+    </tbody>
 </table>
 ```
 
@@ -247,18 +255,18 @@ When executed with the `--format=json` option, you can output list in JSON forma
 ```json
 [
   {
-    "Author": "Django Software Foundation",
-    "License": "BSD",
+    "Author": "Django Software Foundation <foundation@djangoproject.com>",
+    "License": "BSD-3-Clause",
     "Name": "Django",
     "URL": "https://www.djangoproject.com/",
-    "Version": "2.0.2"
+    "Version": "6.0.6"
   },
   {
     "Author": "Stuart Bishop",
-    "License": "MIT",
+    "License": "MIT License",
     "Name": "pytz",
     "URL": "http://pythonhosted.org/pytz",
-    "Version": "2017.3"
+    "Version": "2026.2"
   }
 ]
 ```
@@ -271,14 +279,14 @@ This makes pip-licenses a drop-in replacement for LicenseFinder.
 ```json
 [
   {
-    "licenses": ["BSD"],
+    "licenses": ["BSD-3-Clause"],
     "name": "Django",
-    "version": "2.0.2"
+    "version": "6.0.6"
   },
   {
-    "licenses": ["MIT"],
+    "licenses": ["MIT License"],
     "name": "pytz",
-    "version": "2017.3"
+    "version": "2026.2"
   }
 ]
 
@@ -291,8 +299,8 @@ When executed with the `--format=csv` option, you can output list in quoted CSV 
 ```bash
 (venv) $ pip-licenses --format=csv
 "Name","Version","License"
-"Django","2.0.2","BSD"
-"pytz","2017.3","MIT"
+"Django","6.0.6","BSD-3-Clause"
+"pytz","2026.2","MIT License"
 ```
 
 ##### Plain Vertical
@@ -303,11 +311,11 @@ When executed with the `--format=plain-vertical` option, you can output a simple
 ```bash
 (venv) $ pip-licenses --format=plain-vertical --with-license-file --no-license-path
 pytest
-5.3.4
-MIT license
+9.1.1
+MIT
 The MIT License (MIT)
 
-Copyright (c) 2004-2020 Holger Krekel and others
+Copyright (c) 2004 Holger Krekel and others
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -335,8 +343,9 @@ When executed with the `--summary` option, you can output a summary of each lice
 ```bash
 (venv) $ pip-licenses --summary --from=classifier --with-system
  Count  License
- 2      BSD License
- 4      MIT License
+ 2      BSD-3-Clause
+ 4      MIT
+ 1      MIT License
 ```
 
 **Note:** When using this option, only `--order=count` or `--order=license` has an effect for the `--order` option. And using `--with-authors` and `--with-urls` will be ignored.
@@ -357,7 +366,7 @@ When executed with the `--ignore-packages` option, ignore the package specified 
 ```bash
 (venv) $ pip-licenses --ignore-packages django
  Name  Version  License
- pytz  2017.3   MIT
+ pytz  2026.2   MIT License
 ```
 
 Package names of arguments can be separated by spaces.
@@ -365,20 +374,20 @@ Package names of arguments can be separated by spaces.
 ```bash
 (venv) $ pip-licenses --with-system --ignore-packages django pip pip-licenses
  Name        Version  License
- prettytable 3.16.0   BSD License
- pytz        2017.3   MIT
- setuptools  38.5.0   UNKNOWN
- wcwidth     0.2.5    MIT License
+ prettytable 3.18.0   BSD-3-Clause
+ pytz        2026.2   MIT License
+ setuptools  82.0.1   MIT
+ wcwidth     0.8.2    MIT
 ```
 
 Packages can also be specified with a version, only ignoring that specific version.
 
 ```bash
-(venv) $ pip-licenses --with-system --ignore-packages django pytz:2017.3
+(venv) $ pip-licenses --with-system --ignore-packages django pytz:2026.2
  Name        Version  License
- prettytable 3.16.0   BSD License
- setuptools  38.5.0   UNKNOWN
- wcwidth     0.2.5    MIT License
+ prettytable 3.18.0   BSD-3-Clause
+ setuptools  82.0.1   MIT
+ wcwidth     0.8.2    MIT
 ```
 
 #### Option: packages
@@ -387,17 +396,17 @@ When executed with the `packages` option, look at the package specified by argum
 
 ```bash
 (venv) $ pip-licenses --packages django
- Name   Version  License
- Django 2.0.2    BSD
+ Name    Version  License
+ Django  6.0.6    BSD-3-Clause
 ```
 
 Package names of arguments can be separated by spaces.
 
 ```bash
 (venv) $ pip-licenses --with-system --packages prettytable pytz
- Name        Version  License
- prettytable 3.16.0   BSD License
- pytz        2017.3   MIT
+ Name         Version  License
+ prettytable  3.18.0   BSD-3-Clause
+ pytz         2026.2   MIT License
 ```
 
 ### Format options
@@ -413,13 +422,13 @@ If you want to output all including system package, use the `--with-system` opti
 ```bash
 (venv) $ pip-licenses --with-system
  Name          Version  License
- Django        2.0.2    BSD
- pip           9.0.1    MIT
- pip-licenses  1.0.0    MIT License
- prettytable   3.16.0   BSD License
- pytz          2017.3   MIT
- setuptools    38.5.0   UNKNOWN
- wcwidth       0.2.5    MIT License
+ Django        6.0.6    BSD-3-Clause
+ pip           26.1.2   MIT
+ pip-licenses  5.5.5    MIT
+ prettytable   3.18.0   BSD-3-Clause
+ pytz          2026.2   MIT License
+ setuptools    82.0.1   MIT
+ wcwidth       0.8.2    MIT
 ```
 
 #### Option: with-authors
@@ -428,9 +437,9 @@ When executed with the `--with-authors` option, output with author of the packag
 
 ```bash
 (venv) $ pip-licenses --with-authors
- Name    Version  License  Author
- Django  2.0.2    BSD      Django Software Foundation
- pytz    2017.3   MIT      Stuart Bishop
+ Name    Version  License       Author
+ Django  6.0.6    BSD-3-Clause  Django Software Foundation <foundation@djangoproject.com>
+ pytz    2026.2   MIT License   Stuart Bishop
 ```
 
 #### Option: with-maintainers
@@ -445,9 +454,9 @@ For packages without Metadata, the license is output as `UNKNOWN`. To get more p
 
 ```bash
 (venv) $ pip-licenses --with-urls
- Name    Version  License  URL
- Django  2.0.2    BSD      https://www.djangoproject.com/
- pytz    2017.3   MIT      http://pythonhosted.org/pytz
+ Name    Version  License       URL
+ Django  6.0.6    BSD-3-Clause  https://www.djangoproject.com/
+ pytz    2026.2   MIT License   http://pythonhosted.org/pytz
 ```
 
 #### Option: with-description
@@ -456,9 +465,9 @@ When executed with the `--with-description` option, output with short descriptio
 
 ```bash
 (venv) $ pip-licenses --with-description
- Name    Version  License  Description
- Django  2.0.2    BSD      A high-level Python Web framework that encourages rapid development and clean, pragmatic design.
- pytz    2017.3   MIT      World timezone definitions, modern and historical
+ Name    Version  License       Description
+ Django  6.0.6    BSD-3-Clause  A high-level Python web framework that encourages rapid development and clean, pragmatic design.
+ pytz    2026.2   MIT License   World timezone definitions, modern and historical
 ```
 
 #### Option: no-version
@@ -468,8 +477,8 @@ When executed with the `--no-version` option, output without the version number.
 ```bash
 (venv) $ pip-licenses --no-version
  Name    License
- Django  BSD
- pytz    MIT
+ Django  BSD-3-Clause
+ pytz    MIT License
 ```
 
 #### Option: with-license-file
@@ -518,7 +527,7 @@ If `--from=all`, the option will apply to the metadata license field.
 # keyring library has 2 licenses
 $ pip-licenses --package keyring
  Name     Version  License
- keyring  23.0.1   MIT License; Python Software Foundation License
+ keyring  25.7.0   MIT License; Python Software Foundation License
 
 # If just "Python Software Foundation License" is specified, it will fail.
 $ pip-licenses --package keyring --fail-on="Python Software Foundation License;"
@@ -544,7 +553,7 @@ If `--from=all`, the option will apply to the metadata license field.
 # keyring library has 2 licenses
 $ pip-licenses --package keyring
  Name     Version  License
- keyring  23.0.1   MIT License; Python Software Foundation License
+ keyring  25.7.0   MIT License; Python Software Foundation License
 
 # One or both licenses must be specified (order and case does not matter). Following checks will pass:
 $ pip-licenses --package keyring --allow-only="MIT License"
@@ -576,7 +585,7 @@ Usage:
 # keyring library has 2 licenses
 $ pip-licenses --package keyring
  Name     Version  License
- keyring  23.0.1   MIT License; Python Software Foundation License
+ keyring  25.7.0   MIT License; Python Software Foundation License
 
 # One or both licenses must be specified (order and case does not matter). Following checks will pass:
 $ pip-licenses --package keyring --allow-only="MIT License"
@@ -604,7 +613,7 @@ $ echo $?
 
 ### pyproject.toml support
 
-All command-line options for `pip-licenses` can be configured using the `pyproject.toml` file under the `[tool.pip-licenses]` section. 
+All command-line options for `pip-licenses` can be configured using the `pyproject.toml` file under the `[tool.pip-licenses]` section.
 The `pyproject.toml` file is searched in the directory where the `pip-licenses` script is executed.
 Command-line options specified during execution will override the corresponding options in `pyproject.toml`.
 
@@ -619,7 +628,7 @@ ignore-packages = [
 fail-on = "MIT;"
 ```
 
-If you run `pip-licenses` without any command-line options, all options will be taken from the `pyproject.toml` file. 
+If you run `pip-licenses` without any command-line options, all options will be taken from the `pyproject.toml` file.
 For instance, if you run `pip-licenses --from=mixed`, the `from` option will be overridden to `mixed`, while all other options will be sourced from `pyproject.toml`.
 
 ### More Information


### PR DESCRIPTION
Docker image scanners like AWS security scanner in ECR trigger false alarms on pip-licenses package due to mentioning the old setuptools version (v38.X).

This PR updates all versions in README.md

Let me know if we can find a better solution (somehow avoid README.md from package metadata to avoid future false alarms?)