### PR TITLE
fix: handle filelock Unlicense metadata change in allow-only tests

### DIFF
--- a/test_piplicenses.py
+++ b/test_piplicenses.py
@@ -951,7 +951,7 @@ def test_allow_only(monkeypatch: pytest.MonkeyPatch) -> None:
         "license Unlicense not in allow-only licenses was found for package"
         in mocked_stderr.printed
     )  # GHI #292 -- MIT License has become abbreviated to just MIT for some
-    # GHI #338 -- filelock >=3.23.0 changed license metadata to Unlicense
+    # GHI #338 -- filelock <3.23.0 reports Unlicense instead of MIT
 
 
 def test_allow_only_partial(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -984,7 +984,7 @@ def test_allow_only_partial(monkeypatch: pytest.MonkeyPatch) -> None:
         "license MIT" in mocked_stderr.printed
         or "license Unlicense" in mocked_stderr.printed
     )  # GHI #292 -- partial match may omit 'License'
-    # GHI #338 -- filelock >=3.23.0 changed license metadata to Unlicense
+    # GHI #338 -- filelock <3.23.0 reports Unlicense instead of MIT
 
 
 def test_allow_only_with_empty_tokens(
@@ -1021,7 +1021,7 @@ def test_allow_only_with_empty_tokens(
         "license Unlicense not in allow-only licenses was found for package"
         in mocked_stderr.printed
     )  # GHI #292 -- MIT License has become abbreviated to just MIT for some
-    # GHI #338 -- filelock >=3.23.0 changed license metadata to Unlicense
+    # GHI #338 -- filelock <3.23.0 reports Unlicense instead of MIT
 
 
 def test_fail_on_with_empty_tokens(

--- a/test_piplicenses.py
+++ b/test_piplicenses.py
@@ -942,14 +942,18 @@ def test_allow_only(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert "" == mocked_stdout.printed
     assert (
-        "license MIT License not in allow-only licenses was found for package"
-        in mocked_stderr.printed
-    ) or (
-        "license MIT not in allow-only licenses was found for package"
-        in mocked_stderr.printed
-    ) or (
-        "license Unlicense not in allow-only licenses was found for package"
-        in mocked_stderr.printed
+        (
+            "license MIT License not in allow-only licenses was found for package"
+            in mocked_stderr.printed
+        )
+        or (
+            "license MIT not in allow-only licenses was found for package"
+            in mocked_stderr.printed
+        )
+        or (
+            "license Unlicense not in allow-only licenses was found for package"
+            in mocked_stderr.printed
+        )
     )  # GHI #292 -- MIT License has become abbreviated to just MIT for some
     # GHI #338 -- filelock <3.23.0 reports Unlicense instead of MIT
 
@@ -1012,14 +1016,18 @@ def test_allow_only_with_empty_tokens(
 
     assert "" == mocked_stdout.printed
     assert (
-        "license MIT License not in allow-only licenses was found for package"
-        in mocked_stderr.printed
-    ) or (
-        "license MIT not in allow-only licenses was found for package"
-        in mocked_stderr.printed
-    ) or (
-        "license Unlicense not in allow-only licenses was found for package"
-        in mocked_stderr.printed
+        (
+            "license MIT License not in allow-only licenses was found for package"
+            in mocked_stderr.printed
+        )
+        or (
+            "license MIT not in allow-only licenses was found for package"
+            in mocked_stderr.printed
+        )
+        or (
+            "license Unlicense not in allow-only licenses was found for package"
+            in mocked_stderr.printed
+        )
     )  # GHI #292 -- MIT License has become abbreviated to just MIT for some
     # GHI #338 -- filelock <3.23.0 reports Unlicense instead of MIT
 

--- a/test_piplicenses.py
+++ b/test_piplicenses.py
@@ -947,7 +947,11 @@ def test_allow_only(monkeypatch: pytest.MonkeyPatch) -> None:
     ) or (
         "license MIT not in allow-only licenses was found for package"
         in mocked_stderr.printed
-    )  # GHI #292 -- MIT License has become abreviated to just MIT for some
+    ) or (
+        "license Unlicense not in allow-only licenses was found for package"
+        in mocked_stderr.printed
+    )  # GHI #292 -- MIT License has become abbreviated to just MIT for some
+    # GHI #338 -- filelock >=3.23.0 changed license metadata to Unlicense
 
 
 def test_allow_only_partial(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -974,11 +978,13 @@ def test_allow_only_partial(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert "" == mocked_stdout.printed
     assert (
-        "license MIT" in mocked_stderr.printed
-    ) and (  # GHI #292 -- partial match may ommit 'License'
         " not in allow-only licenses was found for package"
         in mocked_stderr.printed
-    )
+    ) and (
+        "license MIT" in mocked_stderr.printed
+        or "license Unlicense" in mocked_stderr.printed
+    )  # GHI #292 -- partial match may omit 'License'
+    # GHI #338 -- filelock >=3.23.0 changed license metadata to Unlicense
 
 
 def test_allow_only_with_empty_tokens(
@@ -1011,7 +1017,11 @@ def test_allow_only_with_empty_tokens(
     ) or (
         "license MIT not in allow-only licenses was found for package"
         in mocked_stderr.printed
-    )  # GHI #292 -- MIT License has become abreviated to just MIT for some
+    ) or (
+        "license Unlicense not in allow-only licenses was found for package"
+        in mocked_stderr.printed
+    )  # GHI #292 -- MIT License has become abbreviated to just MIT for some
+    # GHI #338 -- filelock >=3.23.0 changed license metadata to Unlicense
 
 
 def test_fail_on_with_empty_tokens(


### PR DESCRIPTION
## Summary
- filelock changed license metadata from Unlicense to MIT in v3.23.0 (tox-dev/filelock@4aac786, 2026-02-14)
- Since `dev-requirements.txt` allows `filelock>=3.19.1`, CI may install a version before 3.23.0 (Unlicense) or after (MIT)
- Three allow-only tests expected MIT in error output but may see Unlicense depending on resolved version
- Updated assertions to accept either MIT or Unlicense, matching existing MIT License vs MIT pattern (GHI #292)

Fixes raimon49/pip-licenses#338

## Test plan
- [x] Run `pytest test_piplicenses.py -k test_allow_only` — all 3 pass
- [x] Verify no regressions — full suite (77 tests) passes
- [x] Verified with filelock 3.29.3 (MIT) installed