### PR TITLE
DRAFT - Patch known fixes for tests

### DIFF
--- a/test_piplicenses.py
+++ b/test_piplicenses.py
@@ -57,6 +57,7 @@ from piplicenses import (
     select_license_by_source,
     value_to_enum_key,
 )
+from piplicenses.output.tables import _handle_multiple_value_field
 
 if TYPE_CHECKING:
     if sys.version_info >= (3, 10):
@@ -615,7 +616,7 @@ class TestGetLicenses(CommandLineTestCase):
     def test_ignore_packages(self) -> None:
         ignore_pkg_name = "prettytable"
         ignore_packages_args = [
-            f"--ignore-package={ignore_pkg_name}",
+            f"--ignore-packages={ignore_pkg_name}",
             "--with-system",
         ]
         args = self.parser.parse_args(ignore_packages_args)
@@ -627,7 +628,7 @@ class TestGetLicenses(CommandLineTestCase):
     def test_ignore_normalized_packages(self) -> None:
         ignore_pkg_name = "pip-licenses"
         ignore_packages_args = [
-            "--ignore-package=pip_licenses",
+            "--ignore-packages=pip_licenses",
             "--with-system",
         ]
         args = self.parser.parse_args(ignore_packages_args)
@@ -641,7 +642,7 @@ class TestGetLicenses(CommandLineTestCase):
         ignore_pkg_name = "prettytable"
         ignore_pkg_spec = f"{ignore_pkg_name}:1.99.99"
         ignore_packages_args = [
-            f"--ignore-package={ignore_pkg_spec}",
+            f"--ignore-packages={ignore_pkg_spec}",
             "--with-system",
         ]
         args = self.parser.parse_args(ignore_packages_args)
@@ -663,7 +664,7 @@ class TestGetLicenses(CommandLineTestCase):
     def test_with_normalized_packages(self) -> None:
         pkg_name = "typing_extensions"
         only_packages_args = [
-            "--package=typing-extensions",
+            "--packages=typing-extensions",
             "--with-system",
         ]
         args = self.parser.parse_args(only_packages_args)
@@ -967,6 +968,14 @@ class TestGetLicenses(CommandLineTestCase):
         piplicenses.importlib_metadata.distributions = (
             importlib_metadata_distributions_orig
         )
+        self.assertIsNotNone(
+            args.filter_strings,
+            f"can't find filter_strings in {args}",
+        )
+        self.assertIsNotNone(
+            args.filter_code_page,
+            f"can't find filter_code_page in {args}",
+        )
         self.assertNotIn(UNICODE_APPENDIX, packages[-1]["name"])
 
     def test_with_specified_filter(self) -> None:
@@ -1260,7 +1269,7 @@ class TestUtilities(unittest.TestCase):
 
     def test_handle_multiple_value_field_plural_returns_list(self) -> None:
         self.assertEqual(
-            piplicenses._handle_multiple_value_field(
+            _handle_multiple_value_field(
                 "authors", iter(["Alice Example", "Bob Example"])
             ),
             ["Alice Example", "Bob Example"],
@@ -1270,7 +1279,7 @@ class TestUtilities(unittest.TestCase):
         self,
     ) -> None:
         self.assertEqual(
-            piplicenses._handle_multiple_value_field("authors", iter([])),
+            _handle_multiple_value_field("authors", iter([])),
             ["UNKNOWN"],
         )
 
@@ -1278,7 +1287,7 @@ class TestUtilities(unittest.TestCase):
         self,
     ) -> None:
         self.assertEqual(
-            piplicenses._handle_multiple_value_field(
+            _handle_multiple_value_field(
                 "license", iter(["MIT", "BSD-3-Clause"])
             ),
             "MIT",
@@ -1288,7 +1297,7 @@ class TestUtilities(unittest.TestCase):
         self,
     ) -> None:
         self.assertEqual(
-            piplicenses._handle_multiple_value_field("license", iter([])),
+            _handle_multiple_value_field("license", iter([])),
             piplicenses.LICENSE_UNKNOWN,
         )
 
@@ -1296,9 +1305,7 @@ class TestUtilities(unittest.TestCase):
         self,
     ) -> None:
         self.assertEqual(
-            piplicenses._handle_multiple_value_field(
-                "ChangelogS", iter(["v1", "v2"])
-            ),
+            _handle_multiple_value_field("ChangelogS", iter(["v1", "v2"])),
             ["v1", "v2"],
         )
 
@@ -1340,12 +1347,21 @@ def test_output_file_success(monkeypatch: pytest.MonkeyPatch) -> None:
 
     mocked_stdout = MockStdStream()
     mocked_stderr = MockStdStream()
-    monkeypatch.setattr(piplicenses, "open", mocked_open)
+    monkeypatch.setattr(piplicenses.output.consoles, "open", mocked_open)
     monkeypatch.setattr(sys.stdout, "write", mocked_stdout.write)
     monkeypatch.setattr(sys.stderr, "write", mocked_stderr.write)
     monkeypatch.setattr(sys, "exit", lambda n: None)
 
-    save_if_needs("/foo/bar.txt", "license list")
+    try:
+        save_if_needs("/foo/bar.txt", "license list")
+    except SystemExit as _expected:
+        print(
+            f"Caught expected {_expected} (with code {_expected.code}). But Ignoring for test."
+        )
+        err_msg = str(_expected)
+        ext_code: int = next(i for i in _expected.args if isinstance(i, int))
+        assert 0 == ext_code
+
     assert "created path: " in mocked_stdout.printed
     assert "" == mocked_stderr.printed
 
@@ -1356,14 +1372,24 @@ def test_output_file_error(monkeypatch: pytest.MonkeyPatch) -> None:
 
     mocked_stdout = MockStdStream()
     mocked_stderr = MockStdStream()
-    monkeypatch.setattr(piplicenses, "open", mocked_open)
+    monkeypatch.setattr(piplicenses.output.consoles, "open", mocked_open)
     monkeypatch.setattr(sys.stdout, "write", mocked_stdout.write)
     monkeypatch.setattr(sys.stderr, "write", mocked_stderr.write)
     monkeypatch.setattr(sys, "exit", lambda n: None)
 
-    save_if_needs("/foo/bar.txt", "license list")
-    assert "" == mocked_stdout.printed
-    assert "check path: " in mocked_stderr.printed
+    try:
+        save_if_needs("/foo/bar.txt", "license list")
+    except SystemExit as _expected:
+        print(
+            f"Caught expected {_expected} (with code {_expected.code}). But Ignoring for test."
+        )
+        err_msg = str(_expected)
+        assert "check path: " in err_msg
+        ext_code: int = next(i for i in _expected.args if isinstance(i, int))
+        assert 1 == ext_code
+
+    assert "" == mocked_stdout.printed.strip()
+    # assert ("check path: " in mocked_stderr.printed)
 
 
 def test_output_file_none(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1372,7 +1398,12 @@ def test_output_file_none(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(sys.stdout, "write", mocked_stdout.write)
     monkeypatch.setattr(sys.stderr, "write", mocked_stderr.write)
 
-    save_if_needs(None, "license list")
+    try:
+        save_if_needs(None, "license list")  # type: ignore[arg-type]
+    except SystemExit as _expected:
+        print(
+            f"Caught expected {_expected} (with code {_expected.code}). But Ignoring for test."
+        )
     # stdout and stderr are expected not to be called
     assert "" == mocked_stdout.printed
     assert "" == mocked_stderr.printed
@@ -1397,9 +1428,12 @@ def test_allow_only(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(sys.stderr, "write", mocked_stderr.write)
     monkeypatch.setattr(sys, "exit", lambda n: None)
     args = create_parser().parse_args(allow_only_args)
-    create_licenses_table(args)
+    try:
+        create_licenses_table(args)
+    except SystemExit as _expected:
+        print(f"Caught expected {_expected}. But Ignoring for test.")
 
-    assert "" == mocked_stdout.printed
+    assert "" == mocked_stdout.printed.strip()
     assert (
         (
             "license MIT License not in allow-only licenses was found for package"
@@ -1437,9 +1471,12 @@ def test_allow_only_partial(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(sys.stderr, "write", mocked_stderr.write)
     monkeypatch.setattr(sys, "exit", lambda n: None)
     args = create_parser().parse_args(allow_only_args)
-    create_licenses_table(args)
+    try:
+        create_licenses_table(args)
+    except SystemExit as _expected:
+        print(f"Caught expected {_expected}. But Ignoring for test.")
 
-    assert "" == mocked_stdout.printed
+    assert "" == mocked_stdout.printed.strip()
     assert (
         " not in allow-only licenses was found for package"
         in mocked_stderr.printed
@@ -1473,9 +1510,12 @@ def test_allow_only_with_empty_tokens(
     monkeypatch.setattr(sys.stderr, "write", mocked_stderr.write)
     monkeypatch.setattr(sys, "exit", lambda n: None)
     args = create_parser().parse_args(allow_only_args)
-    create_licenses_table(args)
+    try:
+        create_licenses_table(args)
+    except SystemExit as _expected:
+        print(f"Caught expected {_expected}. But Ignoring for test.")
 
-    assert "" == mocked_stdout.printed
+    assert "" == mocked_stdout.printed.strip()
     assert (
         (
             "license MIT License not in allow-only licenses was found for package"
@@ -1505,9 +1545,12 @@ def test_fail_on_with_empty_tokens(
     monkeypatch.setattr(sys.stderr, "write", mocked_stderr.write)
     monkeypatch.setattr(sys, "exit", lambda n: None)
     args = create_parser().parse_args(fail_on_args)
-    create_licenses_table(args)
+    try:
+        create_licenses_table(args)
+    except SystemExit as _expected:
+        print(f"Caught expected {_expected}. But Ignoring for test.")
 
-    assert "" == mocked_stdout.printed
+    assert "" == mocked_stdout.printed.strip()
     assert (
         "fail-on license MIT License was found for package"
         in mocked_stderr.printed
@@ -1555,9 +1598,12 @@ def test_fail_on(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(sys.stderr, "write", mocked_stderr.write)
     monkeypatch.setattr(sys, "exit", lambda n: None)
     args = create_parser().parse_args(allow_only_args)
-    create_licenses_table(args)
+    try:
+        create_licenses_table(args)
+    except SystemExit as _expected:
+        print(f"Caught expected {_expected}. But Ignoring for test.")
 
-    assert "" == mocked_stdout.printed
+    assert "" == mocked_stdout.printed.strip()
     assert (
         "fail-on license MIT License was found for package"
         in mocked_stderr.printed
@@ -1576,9 +1622,12 @@ def test_fail_on_partial_match(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(sys.stderr, "write", mocked_stderr.write)
     monkeypatch.setattr(sys, "exit", lambda n: None)
     args = create_parser().parse_args(allow_only_args)
-    create_licenses_table(args)
+    try:
+        create_licenses_table(args)
+    except SystemExit as _expected:
+        print(f"Caught expected {_expected}. But Ignoring for test.")
 
-    assert "" == mocked_stdout.printed
+    assert "" == mocked_stdout.printed.strip()
     assert (
         "fail-on license MIT" in mocked_stderr.printed
     ) and (  # GHI 292 -- partial match may ommit 'License'
@@ -1831,7 +1880,9 @@ def test_pyproject_toml_args_parsed_correctly() -> None:
     # assert values are correctly parsed from toml
     assert args.from_ == FromArg.CLASSIFIER
     assert args.summary == tool_conf["summary"]
-    assert args.ignore_packages == tool_conf["ignore-packages"]
+    assert isinstance(args.ignore_packages, set)  # should be a set
+    # but toml can't encode sets so re-cast to list and sort before compare
+    assert sorted(args.ignore_packages) == tool_conf["ignore-packages"]
     assert args.fail_on == tool_conf["fail-on"]
 
     # assert args are rewritable using cli
@@ -1842,7 +1893,9 @@ def test_pyproject_toml_args_parsed_correctly() -> None:
 
     # all other are parsed from toml
     assert args.summary == tool_conf["summary"]
-    assert args.ignore_packages == tool_conf["ignore-packages"]
+    assert isinstance(args.ignore_packages, set)  # should be a set
+    # but toml can't encode sets so re-cast to list before compare
+    assert sorted(args.ignore_packages) == tool_conf["ignore-packages"]
     assert args.fail_on == tool_conf["fail-on"]
 
     os.unlink(temp_file.name)


### PR DESCRIPTION
Without these known fixes testing, CI/CD is expected to fail with PR #361 (e.g., v6.0.0b7 and related) changes, because of:

>  * an internal function (e.g., previously `piplicenses._handle_multiple_value_field`) has moved (and will not be part of a publicly exposed API, and will need to be imported directly for testing). The _known fix_ is to append `from piplicenses.output.tables import _handle_multiple_value_field` to the imports in `test_piplicenses.py`
>  * restricted effect of monkey-patching directly breaks monkey-patching in tests without a corresponding code change to focus the monkey-patches. The _known fix_ is to refactor all monkey-patching of `open` (previously applied generally in `piplicenses`) to focus only on patching `open` used for writing operations selectively (namely those for file serialization, e.g. currently `piplicenses.output.consoles`) by replacing:
>    ```diff
>    - monkeypatch.setattr(piplicenses, "open", mocked_open)
>    + monkeypatch.setattr(piplicenses.output.consoles, "open", mocked_open)
>    ```
>  * Early aborts now (and soon all early exits, will) raise the built-in [SystemExit](https://docs.python.org/3/library/exceptions.html#SystemExit) instead of directly calling `sys.exit(...)`. While subtle, this change, is still known to have rendered the mocking of system exits in failure-validation testing. The _known fix_ is to handle and even `assert` the `SystemExit`
>  * due to the new `Configuration` data class (W.I.P.) some tests that relied on a stable _order_ when comparing multi-value fields need to be sorted in testing to remain reproducible. Namely the _known fix_ is to sort parsed `set` values when comparing to `lists` via the `sorted` Python builtin.

This patch enumerates the known fixes.

These fixes do not resolve CI/CD failures related to:

>  * _New_ test coverage gaps (e.g., from legacy compatibility re-exports, etc.) remain where new testing will be needed. These remain as Technical debt (for this PR) and will be explored, after the afore-mentioned _known fixes_ are applied in the next patch, in-order to complete GHI-316.

* See-also GHI #316
* See-also PR #361