### PR TITLE
New Feature: markdown support for license files (paths only)

### DIFF
--- a/piplicenses/__init__.py
+++ b/piplicenses/__init__.py
@@ -55,7 +55,7 @@ from .tomli_bridge import tomllib
 
 # Must declare this ASAP as most other component will re-import it
 __pkgname__ = "pip-licenses"  # expose package name with a dash (but canonicalized will ignore dash)
-__version__ = "6.0.0b9"  # (PEP-440 version)
+__version__ = "6.0.0b10"  # (PEP-440 version)
 # Rationale: Try to declare these early too,
 #   as most other component will also re-import this from the package scope
 #   this keeps the .constants package internal and somewhat hidden for now

--- a/piplicenses/cli/config.py
+++ b/piplicenses/cli/config.py
@@ -330,7 +330,7 @@ class Configuration(argparse.Namespace):
             "with_urls",
             "with_description",
             "with_license_files",
-            "with_notice_file",
+            "with_notice_file",  # BUG
             "with_notice_files",
             "with_other_files",
             "without_license_paths",

--- a/piplicenses/core.py
+++ b/piplicenses/core.py
@@ -274,13 +274,58 @@ def extract_homepage(metadata: Message) -> Union[str, None]:
 
 
 def extract_license_from_classifiers(metadata: Message) -> list[str]:
-    classifiers: list[str] = metadata.get_all("classifier", [])
-    license_classifiers: list[str] = find_license_from_classifier(classifiers)
+    classifiers: list[str] = metadata.get_all("Classifier", [])
+    license_classifiers: list[str] = sorted(
+        find_license_from_classifier(classifiers)
+    )
+    # TODO: raise warning if metadata indicates version is 2.4+ -- see PEP 639
     return license_classifiers
 
 
+def extract_authors(metadata: Message) -> list[str]:
+    _combined_authors = set()
+    # start with Core Metadata 1.0 authors
+    # see https://packaging.python.org/en/latest/specifications/core-metadata/#author
+    _auths = metadata.get_all("Author", [])
+    if len(_auths) >= 1:
+        # the spec just expects a single string instance,
+        # but better to handle count-agnostically
+        for _auth in _auths:
+            _combined_authors.add(_auth.strip())
+    # continue with Core Metadata 1.0 and inspect RFC-822 style author-email entries
+    # see https://packaging.python.org/en/latest/specifications/core-metadata/#author-email
+    _emails = metadata.get_all("Author-Email", [])
+    # Per RFC-822, this field may contain multiple comma-separated e-mail addresses:
+    for _auth_entry in _emails:
+        _combined_authors.add(_auth_entry.split(" <")[0])
+    # TODO: should normalize as per RFC-822
+    return sorted(_combined_authors)
+
+
+def extract_maintainers(metadata: Message) -> list[str]:
+    _combined_maintainers = set()
+    # start with Core Metadata 1.2 Maintainers
+    # see https://packaging.python.org/en/latest/specifications/core-metadata/#maintainer
+    _auths = metadata.get_all("Maintainer", [])
+    if len(_auths) >= 1:
+        # the spec just expects a single string instance,
+        # but better to handle count-agnostically
+        for _auth in _auths:
+            _combined_maintainers.add(_auth.strip())
+    # continue with Core Metadata 1.2 and inspect RFC-822 style maintainer-email entries
+    # see https://packaging.python.org/en/latest/specifications/core-metadata/#maintainer-email
+    _emails = metadata.get_all("Maintainer-Email", [])
+    # Per RFC-822, this field may contain multiple comma-separated e-mail addresses:
+    for _auth_entry in _emails:
+        _combined_maintainers.add(_auth_entry.split(" <")[0])
+    # TODO: should normalize as per RFC-822
+    return sorted(_combined_maintainers)
+
+
 # placeholder for something like
-# Value: TypeAlias = Union[str, list[str], dict[str, Union[str, list[str], NoneType]], NoneType]
+# Value: TypeAlias = Union[str, list[str], dict[str, Union[str, list[str], None]], None]
+# E.g., Value: TypeAlias = Union[strs, dict[str, Union[strs, None]], None]
+# E.g., Value: TypeAlias = Optional[Union[strs, dict[str, Optional[strs]]]]
 # See https://github.com/raimon49/pip-licenses/issues/360
 
 
@@ -296,23 +341,20 @@ METADATA_KEYS: dict[
     ],
 ] = {
     "home-page": [extract_homepage],
-    "author": [
-        lambda metadata: metadata.get("author"),
-        lambda metadata: metadata.get("author-email"),
-    ],
+    "author": [extract_authors],
     "maintainer": [
-        lambda metadata: metadata.get("maintainer"),
-        lambda metadata: metadata.get("maintainer-email"),
+        lambda metadata: metadata.get("Maintainer"),
+        lambda metadata: metadata.get("Maintainer-email"),
     ],
-    "license": [lambda metadata: metadata.get("license")],
+    "license": [lambda metadata: metadata.get("License")],
     "license_classifier": [extract_license_from_classifiers],  # added in v6.0
     "license_expression": [
-        lambda metadata: metadata.get("license-expression")
+        lambda metadata: metadata.get("License-expression")
     ],
     "license_files": [
         lambda metadata: metadata.get_all("License-File", [])
     ],  # added in v6.0
-    "summary": [lambda metadata: metadata.get("summary")],
+    "summary": [lambda metadata: metadata.get("Summary")],
     "urls": [extract_urls],  # added in v6.0
 }
 
@@ -717,7 +759,7 @@ def get_packages(
         ):
             continue
 
-        if pkgs_as_normalize and pkg_name.lower() not in pkgs_as_normalize:
+        if pkgs_as_normalize and pkg_name not in pkgs_as_normalize:
             continue
 
         if not args.with_system and pkg_name in SYSTEM_PACKAGES:

--- a/piplicenses/core.py
+++ b/piplicenses/core.py
@@ -342,10 +342,7 @@ METADATA_KEYS: dict[
 ] = {
     "home-page": [extract_homepage],
     "author": [extract_authors],
-    "maintainer": [
-        lambda metadata: metadata.get("Maintainer"),
-        lambda metadata: metadata.get("Maintainer-email"),
-    ],
+    "maintainer": [extract_maintainers],
     "license": [lambda metadata: metadata.get("License")],
     "license_classifier": [extract_license_from_classifiers],  # added in v6.0
     "license_expression": [

--- a/piplicenses/output/__init__.py
+++ b/piplicenses/output/__init__.py
@@ -32,6 +32,7 @@
 To be documented.
 """
 
+import hashlib
 from functools import partial
 from typing import (
     Union,
@@ -107,6 +108,7 @@ def get_output_fields(args: Configuration) -> list[str]:
         output_fields.append("License-Classifier")
         output_fields.append("License-Expression")
     else:
+        # TODO: handle combos for JSON, and plain vertical
         output_fields.append("License")
 
     if args.with_authors:
@@ -123,49 +125,74 @@ def get_output_fields(args: Configuration) -> list[str]:
 
     if args.no_version:
         output_fields.remove("Version")
-
-    # TODO: This workaround for GHI-71 (and related GHI-242) is from Alpha-v6.0.0 and
-    # was inspired by stefan6419846/pip-licenses-cli#32 (and thus CAN NOT be included as is)
-    # because this is really more about argument parsing and validation it is considered a
-    # REGRESSION for the rest of the v6-beta path and should be removed by 6.1.x
+    # see PEP-387
+    # see https://docs.python.org/3/library/exceptions.html#PendingDeprecationWarning
     # e.g., if not ("6.1" in __version__ and "6" in __version__ and "6.0" not in __version__):
     if args.with_license_files and args.format_ not in [
         FormatArg.JSON,
         FormatArg.PLAIN_VERTICAL,
     ]:
-        if args.format_ != FormatArg.HTML:
+        if args.format_ not in (
+            FormatArg.MARKDOWN,
+            FormatArg.RST,
+            FormatArg.CONFLUENCE,
+            FormatArg.HTML,
+        ):
             args.with_license_files = False  # unsupported combo
+        # these are only supported in JSON and plain vertical
         args.with_notice_file = False
         args.with_notice_files = False
         args.with_other_files = False
-    # ... else: raise NotImplemented("overdue tech-debt") from None
 
     if args.no_file_paths:
         args.no_license_path = True
+
+    _format_supports_file_text_data = False
+    if args.format_ in (
+        FormatArg.JSON,
+        FormatArg.PLAIN_VERTICAL,
+        FormatArg.HTML,
+    ):
+        _format_supports_file_text_data = True
 
     if args.with_license_file or args.with_license_files:
         if not args.no_license_path:
             output_fields.append(
                 "LicenseFiles" if args.with_license_files else "LicenseFile"
             )
-
-        output_fields.append(
-            "LicenseTexts" if args.with_license_files else "LicenseText"
-        )
+        if _format_supports_file_text_data:
+            output_fields.append(
+                "LicenseTexts" if args.with_license_files else "LicenseText"
+            )
 
         if args.with_notice_file or args.with_notice_files:
             if not args.no_file_paths:
                 output_fields.append(
                     "NoticeFiles" if args.with_notice_files else "NoticeFile"
                 )
-            output_fields.append("NoticeText")
+            if _format_supports_file_text_data:
+                output_fields.append("NoticeText")
 
         if args.with_other_files:
             if not args.no_file_paths:
                 output_fields.append("OtherFiles")
-            output_fields.append("OtherText")
+            if _format_supports_file_text_data:
+                output_fields.append("OtherText")
 
     return output_fields
+
+
+def _create_stable_table_id(table_as_string: str) -> str:
+    """Normalized SHA-256 hash based ID for the table with the given table string"""
+    _seed = b""
+    if table_as_string:
+        # this is rather expensive but should ensure a stable result
+        _seed = table_as_string.encode(
+            encoding="utf-8", errors="backslashreplace"
+        )
+    _hashed_table = hashlib.sha3_256(_seed, usedforsecurity=False)
+    _composed_id: str = f"pipl_tbl_{_hashed_table.hexdigest()}"
+    return _composed_id
 
 
 def create_output_string(args: Configuration) -> str:
@@ -179,7 +206,14 @@ def create_output_string(args: Configuration) -> str:
     sortby = get_sortby(args)
 
     if args.format_ == FormatArg.HTML:
-        html = table.get_html_string(fields=output_fields, sortby=sortby)
+        _tbl_id = _create_stable_table_id(
+            table.get_string(fields=output_fields, sortby=sortby)
+        )
+        html = table.get_html_string(
+            fields=output_fields,
+            sortby=sortby,
+            attributes={"id": _tbl_id, "class": "pip_licenses_table"},
+        )
         return html.encode("ascii", errors="xmlcharrefreplace").decode("ascii")
     else:
         return table.get_string(fields=output_fields, sortby=sortby)

--- a/piplicenses/output/__init__.py
+++ b/piplicenses/output/__init__.py
@@ -150,6 +150,7 @@ def get_output_fields(args: Configuration) -> list[str]:
     _format_supports_file_text_data = False
     if args.format_ in (
         FormatArg.JSON,
+        FormatArg.PLAIN,
         FormatArg.PLAIN_VERTICAL,
         FormatArg.HTML,
     ):

--- a/piplicenses/output/tables.py
+++ b/piplicenses/output/tables.py
@@ -86,6 +86,10 @@ def factory_styled_table_with_args(
         FormatArg.JSON,
     )
     table.header = True
+    if hasattr(table, "break_on_hyphens") and table.border:
+        table.break_on_hyphens = (
+            False  # changed in v6.0+ -- to support PrettyTable 3.12-3.16
+        )
 
     if args.format_ == FormatArg.MARKDOWN:
         table.junction_char = "|"
@@ -205,7 +209,7 @@ def create_licenses_table(
                     value = pkg[FIELDS_TO_METADATA_KEYS[field]]
                     if value:
                         if field in DYNAMIC_FIELD_NAMES:
-                            row.append(
+                            _value_as_list = sorted(
                                 cast(
                                     list[str],
                                     _handle_multiple_value_field(
@@ -214,6 +218,15 @@ def create_licenses_table(
                                     ),
                                 )
                             )
+                            if args.format_ in (
+                                FormatArg.JSON,
+                                FormatArg.PLAIN_VERTICAL,
+                            ):  # Prototype
+                                row.append(
+                                    _value_as_list,
+                                )
+                            else:
+                                row.append(", ".join(_value_as_list))
                         else:
                             row.append(cast(str, value))
                     else:  # invalid value (e.g. None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 	"Typing :: Typed"
 ]
 dependencies = [
-    "prettytable >= 3.12.0",
+    "prettytable >= 3.12.0",  # 3.16.0 is the last to support 3.9
     "tomli >= 2;python_version<'3.11'"
 ]
 scripts = { "pip-licenses" = "piplicenses.__main__:main" }

--- a/test_piplicenses.py
+++ b/test_piplicenses.py
@@ -863,8 +863,22 @@ class TestGetLicenses(CommandLineTestCase):
         args = self.parser.parse_args(format_html_args)
         output_string = create_output_string(args)
 
-        self.assertIn("<table>", output_string)
+        self.assertIn("<table", output_string)
+        self.assertIn("<thead>", output_string)
+        self.assertIn("<tbody>", output_string)
+        self.assertIn("<tr>", output_string)
+        self.assertIn("<td>", output_string)
         self.assertIn("Filipe La&#237;ns", output_string)  # author of "build"
+
+    def test_format_html_has_attributes(self) -> None:
+        format_html_args = ["--format=html"]
+        args = self.parser.parse_args(format_html_args)
+        output_string = create_output_string(args)
+
+        self.assertIn("<table id", output_string)  # added in version 6.0+
+        self.assertIn(
+            'class="pip_licenses_table">', output_string
+        )  # added in version 6.0+
 
     def test_format_json(self) -> None:
         format_json_args = ["--format=json", "--with-authors"]


### PR DESCRIPTION
# Patch Notes

Implemented a new feature to support markdown format for license file paths in output.

E.g.,

```console
$ piplicenses --format=markdown --with-license-files
| Name               | Version | License                                                      | LicenseFiles                                                                            |
|--------------------|---------|--------------------------------------------------------------|-----------------------------------------------------------------------------------------|
| Pygments           | 2.20.0  | BSD-2-Clause                                                 | AUTHORS, LICENSE                                                                        |
| build              | 1.4.4   | MIT                                                          | LICENSE                                                                                 |
| click              | 8.1.8   | BSD License                                                  | UNKNOWN                                                                                 |
| coverage           | 7.10.7  | Apache-2.0                                                   | LICENSE.txt                                                                             |
| distlib            | 0.4.3   | Python Software Foundation License                           | LICENSE.txt                                                                             |
| docutils           | 0.23    | Public Domain; BSD License; GNU General Public License (GPL) | COPYING.rst, licenses/BSD-0-Clause.rst, licenses/BSD-2-Clause.rst, licenses/gpl-3-0.txt |
| exceptiongroup     | 1.3.1   | MIT License                                                  | LICENSE                                                                                 |
| filelock           | 3.32.4  | MIT                                                          | LICENSE                                                                                 |
| importlib_metadata | 8.7.1   | Apache-2.0                                                   | LICENSE                                                                                 |
| iniconfig          | 2.1.0   | MIT                                                          | LICENSE                                                                                 |
| librt              | 0.13.0  | MIT                                                          | LICENSE                                                                                 |
| mypy               | 1.19.1  | MIT License                                                  | LICENSE                                                                                 |
| mypy_extensions    | 1.1.0   | MIT                                                          | LICENSE                                                                                 |
| packaging          | 26.2    | Apache-2.0 OR BSD-2-Clause                                   | LICENSE, LICENSE.APACHE, LICENSE.BSD                                                    |
| pathspec           | 1.1.1   | Mozilla Public License 2.0 (MPL 2.0)                         | LICENSE                                                                                 |
| pip-tools          | 7.6.0   | BSD License                                                  | LICENSE                                                                                 |
| platformdirs       | 4.4.0   | MIT                                                          | LICENSE                                                                                 |
| pluggy             | 1.6.0   | MIT License                                                  | LICENSE                                                                                 |
| pypandoc           | 1.17    | MIT                                                          | LICENSE                                                                                 |
| pyproject_hooks    | 1.2.0   | MIT License                                                  | UNKNOWN                                                                                 |
| pytest             | 8.4.2   | MIT License                                                  | AUTHORS, LICENSE                                                                        |
| pytest-cov         | 7.1.0   | MIT                                                          | AUTHORS.rst, LICENSE                                                                    |
| pytest-runner      | 6.0.1   | MIT License                                                  | LICENSE                                                                                 |
| python-discovery   | 1.5.1   | MIT License                                                  | LICENSE                                                                                 |
| ruff               | 0.16.1  | MIT                                                          | LICENSE                                                                                 |
| tomli_w            | 1.2.0   | MIT License                                                  | UNKNOWN                                                                                 |
| typing_extensions  | 4.16.0  | PSF-2.0                                                      | LICENSE                                                                                 |
| virtualenv         | 21.7.1  | MIT                                                          | LICENSE                                                                                 |
| zipp               | 3.23.1  | MIT                                                          | LICENSE                                                                                 |
```

which renders like so:

| Name               | Version | License                                                      | LicenseFiles                                                                            |
|--------------------|---------|--------------------------------------------------------------|-----------------------------------------------------------------------------------------|
| Pygments           | 2.20.0  | BSD-2-Clause                                                 | AUTHORS, LICENSE                                                                        |
| build              | 1.4.4   | MIT                                                          | LICENSE                                                                                 |
| click              | 8.1.8   | BSD License                                                  | UNKNOWN                                                                                 |
| coverage           | 7.10.7  | Apache-2.0                                                   | LICENSE.txt                                                                             |
| distlib            | 0.4.3   | Python Software Foundation License                           | LICENSE.txt                                                                             |
| docutils           | 0.23    | Public Domain; BSD License; GNU General Public License (GPL) | COPYING.rst, licenses/BSD-0-Clause.rst, licenses/BSD-2-Clause.rst, licenses/gpl-3-0.txt |
| exceptiongroup     | 1.3.1   | MIT License                                                  | LICENSE                                                                                 |
| filelock           | 3.32.4  | MIT                                                          | LICENSE                                                                                 |
| importlib_metadata | 8.7.1   | Apache-2.0                                                   | LICENSE                                                                                 |
| iniconfig          | 2.1.0   | MIT                                                          | LICENSE                                                                                 |
| librt              | 0.13.0  | MIT                                                          | LICENSE                                                                                 |
| mypy               | 1.19.1  | MIT License                                                  | LICENSE                                                                                 |
| mypy_extensions    | 1.1.0   | MIT                                                          | LICENSE                                                                                 |
| packaging          | 26.2    | Apache-2.0 OR BSD-2-Clause                                   | LICENSE, LICENSE.APACHE, LICENSE.BSD                                                    |
| pathspec           | 1.1.1   | Mozilla Public License 2.0 (MPL 2.0)                         | LICENSE                                                                                 |
| pip-tools          | 7.6.0   | BSD License                                                  | LICENSE                                                                                 |
| platformdirs       | 4.4.0   | MIT                                                          | LICENSE                                                                                 |
| pluggy             | 1.6.0   | MIT License                                                  | LICENSE                                                                                 |
| pypandoc           | 1.17    | MIT                                                          | LICENSE                                                                                 |
| pyproject_hooks    | 1.2.0   | MIT License                                                  | UNKNOWN                                                                                 |
| pytest             | 8.4.2   | MIT License                                                  | AUTHORS, LICENSE                                                                        |
| pytest-cov         | 7.1.0   | MIT                                                          | AUTHORS.rst, LICENSE                                                                    |
| pytest-runner      | 6.0.1   | MIT License                                                  | LICENSE                                                                                 |
| python-discovery   | 1.5.1   | MIT License                                                  | LICENSE                                                                                 |
| ruff               | 0.16.1  | MIT                                                          | LICENSE                                                                                 |
| tomli_w            | 1.2.0   | MIT License                                                  | UNKNOWN                                                                                 |
| typing_extensions  | 4.16.0  | PSF-2.0                                                      | LICENSE                                                                                 |
| virtualenv         | 21.7.1  | MIT                                                          | LICENSE                                                                                 |
| zipp               | 3.23.1  | MIT                                                          | LICENSE                                                                                 |

* This patch also includes an update for html format to now include `id`/`class` attributes for the generated `<table>` (for possible linking, and CSS/formatting).

* This patch also includes stability fixes for author & maintainer listings, through closer alignment with the core packaging specs.

## Impacted GHIs:

 * Contributes to work on #71 (W.I.P.)
 * Contributes to work on #239 (markdown)
 * Contributes to work on #242 (W.I.P.)
 
 ---
 
 ## Special Thanks
 
 Huge thanks to @johnthagen for suggesting/inspiring this and related features!